### PR TITLE
v0.27.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.27.8**
+* [[TeamMsgExtractor #158](https://github.com/TeamMsgExtractor/msg-extractor/issues/158)] Fixed a spelling error in a function name that was causing it to not be seen. The function was called `ceilDiv` but was accidentally called as `cielDiv`.
+
 **v0.27.7**
 * Fixed an issue in the new bitwise adjustment functions. One of the variable names was incorrect.
 
@@ -7,7 +10,7 @@
 **v0.27.5**
 * Fixed an error in `utils.divide` that would cause it to drop the extra data if there was not enough to create a full division. For example, if you had a string that was 10 characters, and divided by 3, you would only receive a total of 9 characters back.
 * Added some useful functions that will be used in the future.
-* [[TeamMsgExtractor](https://github.com/TeamMsgExtractor/msg-extractor/issues/155)] Updated to use new version of tzlocal.
+* [[TeamMsgExtractor #155](https://github.com/TeamMsgExtractor/msg-extractor/issues/155)] Updated to use new version of tzlocal.
 * Updated changelog to fit new repository.
 
 **v0.27.4**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.27.7**
+* Fixed an issue in the new bitwise adjustment functions. One of the variable names was incorrect.
+
 **v0.27.6**
 * Fixed a few lines in `data.py`.
 

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.6-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.6/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.7-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.7/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.7-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.7/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.8-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.8/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
 __date__ = '2020-10-17'
-__version__ = '0.27.6'
+__version__ = '0.27.7'
 
 import logging
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
 __date__ = '2020-10-17'
-__version__ = '0.27.7'
+__version__ = '0.27.8'
 
 import logging
 

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -140,7 +140,7 @@ def divide(string, length):
     >>>> print(a)
     ['Hello', ' Worl', 'd!']
     """
-    return [string[length * x:length * (x + 1)] for x in range(int(cielDiv(len(string), length)))]
+    return [string[length * x:length * (x + 1)] for x in range(int(ceilDiv(len(string), length)))]
 
 def fromTimeStamp(stamp):
     return datetime.datetime.fromtimestamp(stamp, tzlocal.get_localzone())

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -8,7 +8,6 @@ import datetime
 import json
 import logging
 import logging.config
-import math
 import struct
 import sys
 
@@ -80,7 +79,7 @@ def addNumToDir(dirName):
             pass
     return None
 
-def bitwiseAdjust(result, mask):
+def bitwiseAdjust(inp, mask):
     """
     Uses a given mask to adjust the location of bits after an operation like
     bitwise AND. This is useful for things like flags where you are trying to
@@ -94,7 +93,7 @@ def bitwiseAdjust(result, mask):
     """
     if mask < 1:
         raise ValueError('Mask MUST be greater than 0')
-    return result >> bin(mask)[::-1].index('1')
+    return inp >> bin(mask)[::-1].index('1')
 
 def bitwiseAdjustedAnd(inp, mask):
     """
@@ -103,12 +102,22 @@ def bitwiseAdjustedAnd(inp, mask):
     """
     if mask < 1:
         raise ValueError('Mask MUST be greater than 0')
-    return (result & mask) >> bin(mask)[::-1].index('1')
+    return (inp & mask) >> bin(mask)[::-1].index('1')
 
 def bytesToGuid(bytes_input):
     hexinput = [properHex(byte) for byte in bytes_input]
     hexs = [hexinput[3] + hexinput[2] + hexinput[1] + hexinput[0], hexinput[5] + hexinput[4], hexinput[7] + hexinput[6], hexinput[8] + hexinput[9], ''.join(hexinput[10:16])]
     return '{{{}-{}-{}-{}-{}}}'.format(*hexs).upper()
+
+def ceilDiv(n, d):
+    """
+    Returns the int from the ceil division of n / d.
+    ONLY use ints as inputs to this function.
+
+    For ints, this is faster and more accurate for numbers
+    outside the precision range of float.
+    """
+    return -(n // -d)
 
 def divide(string, length):
     """
@@ -131,7 +140,7 @@ def divide(string, length):
     >>>> print(a)
     ['Hello', ' Worl', 'd!']
     """
-    return [string[length * x:length * (x + 1)] for x in range(int(math.ceil(len(string) / length)))]
+    return [string[length * x:length * (x + 1)] for x in range(int(cielDiv(len(string), length)))]
 
 def fromTimeStamp(stamp):
     return datetime.datetime.fromtimestamp(stamp, tzlocal.get_localzone())


### PR DESCRIPTION
**v0.27.8**
* [[TeamMsgExtractor #158](https://github.com/TeamMsgExtractor/msg-extractor/issues/158)] Fixed a spelling error in a function name that was causing it to not be seen. The function was called `ceilDiv` but was accidentally called as `cielDiv`.