### PR TITLE
v0.27.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 **v0.27.9**
 * [[TeamMsgExtractor #161](https://github.com/TeamMsgExtractor/msg-extractor/issues/161)] Added commands to the command line that will allow the user to specify that they want the message data to be output to stdout rather than to a file.
+* [[TeamMsgExtractor #162](https://github.com/TeamMsgExtractor/msg-extractor/issues/162)] Added a wrapper for extract_msg that will be installed.
 * Fixed some of the encoding names to allow them to actually be used in Python. The names they previously held were not aliases that currently exist.
 * Added more documentation to `constants.CODE_PAGES` to give more information about what it is. As it is a list of the possible encodings an msg file can use, I also specified which ones were supported by Python 3.
+* Moved the main code into a function so it is now callable from outside of the file.
 
 **v0.27.8**
 * [[TeamMsgExtractor #158](https://github.com/TeamMsgExtractor/msg-extractor/issues/158)] Fixed a spelling error in a function name that was causing it to not be seen. The function was called `ceilDiv` but was accidentally called as `cielDiv`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v0.27.9**
+* [[TeamMsgExtractor #161](https://github.com/TeamMsgExtractor/msg-extractor/issues/161)] Added commands to the command line that will allow the user to specify that they want the message data to be output to stdout rather than to a file.
+* Fixed some of the encoding names to allow them to actually be used in Python. The names they previously held were not aliases that currently exist.
+* Added more documentation to `constants.CODE_PAGES` to give more information about what it is. As it is a list of the possible encodings an msg file can use, I also specified which ones were supported by Python 3.
+
 **v0.27.8**
 * [[TeamMsgExtractor #158](https://github.com/TeamMsgExtractor/msg-extractor/issues/158)] Fixed a spelling error in a function name that was causing it to not be seen. The function was called `ceilDiv` but was accidentally called as `cielDiv`.
 

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.8-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.8/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.9-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.9/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
 __date__ = '2020-10-17'
-__version__ = '0.27.8'
+__version__ = '0.27.9'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -38,13 +38,17 @@ if __name__ == '__main__':
             fil.write(json.dumps(val_results))
         utils.get_input('Press enter to exit...')
     else:
-        utils.setup_logging(args.config_path, level, args.log, args.file_logging)
+        if not args.dump_stdout:
+            utils.setup_logging(args.config_path, level, args.log, args.file_logging)
         for x in args.msgs:
             try:
                 with Message(x[0]) as msg:
                     # Right here we should still be in the path in currentdir
-                    os.chdir(out)
-                    msg.save(toJson = args.json, useFileName = args.use_filename, ContentId = args.cid)#, html = args.html, rtf = args.html)
+                    if args.dump_stdout:
+                        print(msg.body)
+                    else:
+                        os.chdir(out)
+                        msg.save(toJson = args.json, useFileName = args.use_filename, ContentId = args.cid)#, html = args.html, rtf = args.html)
             except Exception as e:
                 print("Error with file '" + x[0] + "': " +
                       traceback.format_exc())

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -6,7 +6,7 @@ from extract_msg import __doc__, utils
 from extract_msg.compat import os_ as os
 from extract_msg.message import Message
 
-if __name__ == '__main__':
+def main():
     # Setup logging to stdout, indicate running from cli
     CLI_LOGGING = 'extract_msg_cli'
 
@@ -53,3 +53,6 @@ if __name__ == '__main__':
                 print("Error with file '" + x[0] + "': " +
                       traceback.format_exc())
             os.chdir(currentdir)
+
+if __name__ == '__main__':
+    main()

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -118,30 +118,51 @@ VARIABLE_LENGTH_PROPS_STRING = (
     '1102',
 )
 
+
+# This is a dictionary matching the code page number to it's encoding name.
+# The list used to make this can be found here:
+# https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+### TODO:
+# Many of these code pages are not supported by Python. As such, we should
+# Really implement them ourselves to make sure that if someone wants to use an
+# msg file with one of those encodings, they are able to. Perhaps we should
+# create a seperate module for that?
+# Code pages that currently don't have a supported encoding will be preceded by
+# `# UNSUPPORTED`.
+# For some of these, it is also possible that the name we are trying to find
+# them with is not known to Python. I have already confirmed this for a few of
+# them, and adjusted their names to ones that python would recognize. It is
+# Possible I missed a few.
 CODE_PAGES = {
     37: 'IBM037', # IBM EBCDIC US-Canada
     437: 'IBM437', # OEM United States
     500: 'IBM500', # IBM EBCDIC International
     708: 'ASMO-708', # Arabic (ASMO 708)
+    # UNSUPPORTED
     709: '', # Arabic (ASMO-449+, BCON V4)
+    # UNSUPPORTED
     710: '', # Arabic - Transparent Arabic
+    # UNSUPPORTED
     720: 'DOS-720', # Arabic (Transparent ASMO); Arabic (DOS)
-    737: 'ibm737', # OEM Greek (formerly 437G); Greek (DOS)
+    737: 'cp737', # OEM Greek (formerly 437G); Greek (DOS)
     775: 'ibm775', # OEM Baltic; Baltic (DOS)
     850: 'ibm850', # OEM Multilingual Latin 1; Western European (DOS)
     852: 'ibm852', # OEM Latin 2; Central European (DOS)
     855: 'IBM855', # OEM Cyrillic (primarily Russian)
     857: 'ibm857', # OEM Turkish; Turkish (DOS)
+    # UNSUPPORTED
     858: 'IBM00858', # OEM Multilingual Latin 1 + Euro symbol
     860: 'IBM860', # OEM Portuguese; Portuguese (DOS)
     861: 'ibm861', # OEM Icelandic; Icelandic (DOS)
-    862: 'DOS-862', # OEM Hebrew; Hebrew (DOS)
+    862: 'cp862', # OEM Hebrew; Hebrew (DOS)
     863: 'IBM863', # OEM French Canadian; French Canadian (DOS)
     864: 'IBM864', # OEM Arabic; Arabic (864)
     865: 'IBM865', # OEM Nordic; Nordic (DOS)
     866: 'cp866', # OEM Russian; Cyrillic (DOS)
     869: 'ibm869', # OEM Modern Greek; Greek, Modern (DOS)
+    # UNSUPPORTED
     870: 'IBM870', # IBM EBCDIC Multilingual/ROECE (Latin 2); IBM EBCDIC Multilingual Latin 2
+    # UNSUPPORTED
     874: 'windows-874', # ANSI/OEM Thai (ISO 8859-11); Thai (Windows)
     875: 'cp875', # IBM EBCDIC Greek Modern
     932: 'shift_jis', # ANSI/OEM Japanese; Japanese (Shift-JIS)
@@ -149,19 +170,30 @@ CODE_PAGES = {
     949: 'ks_c_5601-1987', # ANSI/OEM Korean (Unified Hangul Code)
     950: 'big5', # ANSI/OEM Traditional Chinese (Taiwan; Hong Kong SAR, PRC); Chinese Traditional (Big5)
     1026: 'IBM1026', # IBM EBCDIC Turkish (Latin 5)
+    # UNSUPPORTED
     1047: 'IBM01047', # IBM EBCDIC Latin 1/Open System
+    # UNSUPPORTED
     1140: 'IBM01140', # IBM EBCDIC US-Canada (037 + Euro symbol); IBM EBCDIC (US-Canada-Euro)
+    # UNSUPPORTED
     1141: 'IBM01141', # IBM EBCDIC Germany (20273 + Euro symbol); IBM EBCDIC (Germany-Euro)
+    # UNSUPPORTED
     1142: 'IBM01142', # IBM EBCDIC Denmark-Norway (20277 + Euro symbol); IBM EBCDIC (Denmark-Norway-Euro)
+    # UNSUPPORTED
     1143: 'IBM01143', # IBM EBCDIC Finland-Sweden (20278 + Euro symbol); IBM EBCDIC (Finland-Sweden-Euro)
+    # UNSUPPORTED
     1144: 'IBM01144', # IBM EBCDIC Italy (20280 + Euro symbol); IBM EBCDIC (Italy-Euro)
+    # UNSUPPORTED
     1145: 'IBM01145', # IBM EBCDIC Latin America-Spain (20284 + Euro symbol); IBM EBCDIC (Spain-Euro)
+    # UNSUPPORTED
     1146: 'IBM01146', # IBM EBCDIC United Kingdom (20285 + Euro symbol); IBM EBCDIC (UK-Euro)
+    # UNSUPPORTED
     1147: 'IBM01147', # IBM EBCDIC France (20297 + Euro symbol); IBM EBCDIC (France-Euro)
+    # UNSUPPORTED
     1148: 'IBM01148', # IBM EBCDIC International (500 + Euro symbol); IBM EBCDIC (International-Euro)
+    # UNSUPPORTED
     1149: 'IBM01149', # IBM EBCDIC Icelandic (20871 + Euro symbol); IBM EBCDIC (Icelandic-Euro)
-    1200: 'utf-16', # Unicode UTF-16, little endian byte order (BMP of ISO 10646); available only to managed applications
-    1201: 'unicodeFFFE', # Unicode UTF-16, big endian byte order; available only to managed applications
+    1200: 'utf-16-le', # Unicode UTF-16, little endian byte order (BMP of ISO 10646); available only to managed applications
+    1201: 'utf-16-be', # Unicode UTF-16, big endian byte order; available only to managed applications
     1250: 'windows-1250', # ANSI Central European; Central European (Windows)
     1251: 'windows-1251', # ANSI Cyrillic; Cyrillic (Windows)
     1252: 'windows-1252', # ANSI Latin 1; Western European (Windows)
@@ -174,57 +206,101 @@ CODE_PAGES = {
     1361: 'Johab', # Korean (Johab)
     10000: 'macintosh', # MAC Roman; Western European (Mac)
     10001: 'x-mac-japanese', # Japanese (Mac)
+    # UNSUPPORTED
     10002: 'x-mac-chinesetrad', # MAC Traditional Chinese (Big5); Chinese Traditional (Mac)
     10003: 'x-mac-korean', # Korean (Mac)
+    # UNSUPPORTED
     10004: 'x-mac-arabic', # Arabic (Mac)
+    # UNSUPPORTED
     10005: 'x-mac-hebrew', # Hebrew (Mac)
+    # UNSUPPORTED
     10006: 'x-mac-greek', # Greek (Mac)
+    # UNSUPPORTED
     10007: 'x-mac-cyrillic', # Cyrillic (Mac)
+    # UNSUPPORTED
     10008: 'x-mac-chinesesimp', # MAC Simplified Chinese (GB 2312); Chinese Simplified (Mac)
+    # UNSUPPORTED
     10010: 'x-mac-romanian', # Romanian (Mac)
+    # UNSUPPORTED
     10017: 'x-mac-ukrainian', # Ukrainian (Mac)
+    # UNSUPPORTED
     10021: 'x-mac-thai', # Thai (Mac)
+    # UNSUPPORTED
     10029: 'x-mac-ce', # MAC Latin 2; Central European (Mac)
+    # UNSUPPORTED
     10079: 'x-mac-icelandic', # Icelandic (Mac)
+    # UNSUPPORTED
     10081: 'x-mac-turkish', # Turkish (Mac)
+    # UNSUPPORTED
     10082: 'x-mac-croatian', # Croatian (Mac)
     12000: 'utf-32', # Unicode UTF-32, little endian byte order; available only to managed applications
     12001: 'utf-32BE', # Unicode UTF-32, big endian byte order; available only to managed applications
+    # UNSUPPORTED
     20000: 'x-Chinese_CNS', # CNS Taiwan; Chinese Traditional (CNS)
+    # UNSUPPORTED
     20001: 'x-cp20001', # TCA Taiwan
+    # UNSUPPORTED
     20002: 'x_Chinese-Eten', # Eten Taiwan; Chinese Traditional (Eten)
+    # UNSUPPORTED
     20003: 'x-cp20003', # IBM5550 Taiwan
+    # UNSUPPORTED
     20004: 'x-cp20004', # TeleText Taiwan
+    # UNSUPPORTED
     20005: 'x-cp20005', # Wang Taiwan
+    # UNSUPPORTED
     20105: 'x-IA5', # IA5 (IRV International Alphabet No. 5, 7-bit); Western European (IA5)
+    # UNSUPPORTED
     20106: 'x-IA5-German', # IA5 German (7-bit)
+    # UNSUPPORTED
     20107: 'x-IA5-Swedish', # IA5 Swedish (7-bit)
+    # UNSUPPORTED
     20108: 'x-IA5-Norwegian', # IA5 Norwegian (7-bit)
     20127: 'us-ascii', # US-ASCII (7-bit)
+    # UNSUPPORTED
     20261: 'x-cp20261', # T.61
+    # UNSUPPORTED
     20269: 'x-cp20269', # ISO 6937 Non-Spacing Accent
     20273: 'IBM273', # IBM EBCDIC Germany
+    # UNSUPPORTED
     20277: 'IBM277', # IBM EBCDIC Denmark-Norway
+    # UNSUPPORTED
     20278: 'IBM278', # IBM EBCDIC Finland-Sweden
+    # UNSUPPORTED
     20280: 'IBM280', # IBM EBCDIC Italy
+    # UNSUPPORTED
     20284: 'IBM284', # IBM EBCDIC Latin America-Spain
+    # UNSUPPORTED
     20285: 'IBM285', # IBM EBCDIC United Kingdom
+    # UNSUPPORTED
     20290: 'IBM290', # IBM EBCDIC Japanese Katakana Extended
+    # UNSUPPORTED
     20297: 'IBM297', # IBM EBCDIC France
+    # UNSUPPORTED
     20420: 'IBM420', # IBM EBCDIC Arabic
+    # UNSUPPORTED
     20423: 'IBM423', # IBM EBCDIC Greek
     20424: 'IBM424', # IBM EBCDIC Hebrew
+    # UNSUPPORTED
     20833: 'x-EBCDIC-KoreanExtended', # IBM EBCDIC Korean Extended
+    # UNSUPPORTED
     20838: 'IBM-Thai', # IBM EBCDIC Thai
     20866: 'koi8-r', # Russian (KOI8-R); Cyrillic (KOI8-R)
+    # UNSUPPORTED
     20871: 'IBM871', # IBM EBCDIC Icelandic
+    # UNSUPPORTED
     20880: 'IBM880', # IBM EBCDIC Cyrillic Russian
+    # UNSUPPORTED
     20905: 'IBM905', # IBM EBCDIC Turkish
+    # UNSUPPORTED
     20924: 'IBM00924', # IBM EBCDIC Latin 1/Open System (1047 + Euro symbol)
     20932: 'EUC-JP', # Japanese (JIS 0208-1990 and 0212-1990)
+    # UNSUPPORTED
     20936: 'x-cp20936', # Simplified Chinese (GB2312); Chinese Simplified (GB2312-80)
+    # UNSUPPORTED
     20949: 'x-cp20949', # Korean Wansung
+    # UNSUPPORTED
     21025: 'cp1025', # IBM EBCDIC Cyrillic Serbian-Bulgarian
+    # UNSUPPORTED
     21027: '', # (deprecated)
     21866: 'koi8-u', # Ukrainian (KOI8-U); Cyrillic (KOI8-U)
     28591: 'iso-8859-1', # ISO 8859-1 Latin 1; Western European (ISO)
@@ -238,36 +314,58 @@ CODE_PAGES = {
     28599: 'iso-8859-9', # ISO 8859-9 Turkish
     28603: 'iso-8859-13', # ISO 8859-13 Estonian
     28605: 'iso-8859-15', # ISO 8859-15 Latin 9
+    # UNSUPPORTED
     29001: 'x-Europa', # Europa 3
+    # UNSUPPORTED
     38598: 'iso-8859-8-i', # ISO 8859-8 Hebrew; Hebrew (ISO-Logical)
     50220: 'iso-2022-jp', # ISO 2022 Japanese with no halfwidth Katakana; Japanese (JIS)
     50221: 'csISO2022JP', # ISO 2022 Japanese with halfwidth Katakana; Japanese (JIS-Allow 1 byte Kana)
     50222: 'iso-2022-jp', # ISO 2022 Japanese JIS X 0201-1989; Japanese (JIS-Allow 1 byte Kana - SO/SI)
     50225: 'iso-2022-kr', # ISO 2022 Korean
+    # UNSUPPORTED
     50227: 'x-cp50227', # ISO 2022 Simplified Chinese; Chinese Simplified (ISO 2022)
+    # UNSUPPORTED
     50229: '', # ISO 2022 Traditional Chinese
+    # UNSUPPORTED
     50930: '', # EBCDIC Japanese (Katakana) Extended
+    # UNSUPPORTED
     50931: '', # EBCDIC US-Canada and Japanese
+    # UNSUPPORTED
     50933: '', # EBCDIC Korean Extended and Korean
+    # UNSUPPORTED
     50935: '', # EBCDIC Simplified Chinese Extended and Simplified Chinese
+    # UNSUPPORTED
     50936: '', # EBCDIC Simplified Chinese
+    # UNSUPPORTED
     50937: '', # EBCDIC US-Canada and Traditional Chinese
+    # UNSUPPORTED
     50939: '', # EBCDIC Japanese (Latin) Extended and Japanese
     51932: 'euc-jp', # EUC Japanese
     51936: 'EUC-CN', # EUC Simplified Chinese; Chinese Simplified (EUC)
     51949: 'euc-kr', # EUC Korean
+    # UNSUPPORTED
     51950: '', # EUC Traditional Chinese
     52936: 'hz-gb-2312', # HZ-GB2312 Simplified Chinese; Chinese Simplified (HZ)
     54936: 'GB18030', # Windows XP and later: GB18030 Simplified Chinese (4 byte); Chinese Simplified (GB18030)
+    # UNSUPPORTED
     57002: 'x-iscii-de', # ISCII Devanagari
+    # UNSUPPORTED
     57003: 'x-iscii-be', # ISCII Bangla
+    # UNSUPPORTED
     57004: 'x-iscii-ta', # ISCII Tamil
+    # UNSUPPORTED
     57005: 'x-iscii-te', # ISCII Telugu
+    # UNSUPPORTED
     57006: 'x-iscii-as', # ISCII Assamese
+    # UNSUPPORTED
     57007: 'x-iscii-or', # ISCII Odia
+    # UNSUPPORTED
     57008: 'x-iscii-ka', # ISCII Kannada
+    # UNSUPPORTED
     57009: 'x-iscii-ma', # ISCII Malayalam
+    # UNSUPPORTED
     57010: 'x-iscii-gu', # ISCII Gujarati
+    # UNSUPPORTED
     57011: 'x-iscii-pa', # ISCII Punjabi
     65000: 'utf-7', # Unicode (UTF-7)
     65001: 'utf-8', # Unicode (UTF-8)

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -180,6 +180,9 @@ def get_command_args(args):
     # --use-filename
     parser.add_argument('--use-filename', dest='use_filename', action='store_true',
                         help='Sets whether the name of each output is based on the msg filename.')
+    # --dump-stdout
+    parser.add_argument('--dump-stdout', dest='dump_stdout', action='store_true',
+                        help='Tells the program to dump the message body (plain text) to stdout. Overrides saving arguments.')
     # --html
     #parser.add_argument('--html', dest='html', action='store_true',
     #                    help='Sets whether the output should be html. If this is not possible, will fallback to plain text')
@@ -207,6 +210,18 @@ def get_command_args(args):
 
     if options.dev or options.file_logging:
         options.verbose = True
+
+    # If dump_stdout is True, we need to unset all arguments used in files.
+    # Technically we actually only *need* to unset `out_path`, but that may
+    # change in the future, so let's be thorough.
+    if options.dump_stdout:
+        options.out_path = None
+        options.json = False
+        #options.rtf = False
+        #options.html = False
+        options.use_filename = False
+        options.cid = False
+
     file_args = options.msgs
     file_tables = []  # This is where we will store the separated files and their arguments
     temp_table = []  # temp_table will store each table while it is still being built.

--- a/scripts/extract_msg
+++ b/scripts/extract_msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from extract_msg.__main__ import main
+
+main()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 
 
 # a handful of variables that are used a couple of times
-github_url = 'https://github.com/mattgwwalker/msg-extractor'
+github_url = 'https://github.com/TeamMsgExtractor/msg-extractor'
 main_module = 'extract_msg'
 # main_script = main_module + '.py'
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     license='GPL',
     packages=[main_module],
     py_modules=[main_module],
+    scripts=['scripts/extract_msg'],
     include_package_data=True,
     install_requires=dependencies,
 )


### PR DESCRIPTION
**v0.27.9**
* [[TeamMsgExtractor #161](https://github.com/TeamMsgExtractor/msg-extractor/issues/161)] Added commands to the command line that will allow the user to specify that they want the message data to be output to stdout rather than to a file.
* [[TeamMsgExtractor #162](https://github.com/TeamMsgExtractor/msg-extractor/issues/162)] Added a wrapper for extract_msg that will be installed.
* Fixed some of the encoding names to allow them to actually be used in Python. The names they previously held were not aliases that currently exist.
* Added more documentation to `constants.CODE_PAGES` to give more information about what it is. As it is a list of the possible encodings an msg file can use, I also specified which ones were supported by Python 3.
* Moved the main code into a function so it is now callable from outside of the file.