### PR TITLE
Added RTF de-encapsulation to populate HTML when it is otherwise missing in a msg.   

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.28.0**
+* [[TeamMsgExtractor #137]](https://github.com/TeamMsgExtractor/msg-extractor/issues/137) Added functionality to De-Encapsulate HTML/plain text from an RTF body.
+
 **v0.27.9**
 * [[TeamMsgExtractor #161](https://github.com/TeamMsgExtractor/msg-extractor/issues/161)] Added commands to the command line that will allow the user to specify that they want the message data to be output to stdout rather than to a file.
 * [[TeamMsgExtractor #162](https://github.com/TeamMsgExtractor/msg-extractor/issues/162)] Added a wrapper for extract_msg that will be installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ imapclient==2.1.0
 olefile>=0.46
 tzlocal>=2.1
 compressed_rtf>=1.0.6
-RTFDE>-0.0.1
+RTFDE>=0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ imapclient==2.1.0
 olefile>=0.46
 tzlocal>=2.1
 compressed_rtf>=1.0.6
+RTFDE>-0.0.1


### PR DESCRIPTION
This commit will de-encapsulate HTML content from the RTF body element when htmlBody content is missing. 

- [X] Issue  #137 
- [X] Have you listed any changes to install or build dependencies? **I updated the requirements so the install seamlessly includes the new library.** 
- [X] Have you updated the [CHANGELOG](CHANGELOG.md) with details of changes to the codebase, this includes new functionality, deprecated features, or any other material changes.
- [X] If necessary, have you bumped the version number? We will usually do this for you. **Done, feel free to change/update/move/etc.**
- [X] Have you included py.test tests with your pull request. (Not yet necessary) **I've updated the existing test to include checking the de-encapsulated HTML. But, the larger test suite is broken so it won't run. That said, I wrote the de-encapsulation library for this pull request and included a full test-suite within it.**
- [X] Ensured your code is as close to PEP 8 compliant as possible? **I deviated somewhat to try to keep my additions consistent with the existing codebase naming conventions**
