### PR TITLE
v0.27.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ logging.json
 
 # Developer files
 upload.bat
+upload.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.27.12**
+* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Made an assumption about where an exception was thrown from and was wrong. While that location would have throw an exception, the function that called that code was the one to actually throw the exception in question. This issue *should* be fixed...
+* [[TeamMsgExtractor #162](https://github.com/TeamMsgExtractor/msg-extractor/issues/162)] Made another attempt to fix the execution flag on the wrapper script.
+
 **v0.27.11**
 * [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Tentatively implemented type 0x1014 (PtypMultipleInteger64). Apparently I forgot to do it earlier.
 

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.11-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.11/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.12-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.12/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
 __date__ = '2021-01-01'
-__version__ = '0.27.11'
+__version__ = '0.27.12'
 
 import logging
 

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -236,12 +236,12 @@ class MSGFile(olefile.OleFileIO):
                         streams = len(contents) // 4 # These lengths are normal.
                     elif _type == '1102':
                         streams = len(contents) // 8 # These lengths have 4 0x00 bytes at the end for seemingly no reason. They are "reserved" bytes
-                    elif _type in ('1002', '1003', '1004', '1005', '1007', '1040', '1048'):
+                    elif _type in ('1002', '1003', '1004', '1005', '1007', '1014', '1040', '1048'):
                         try:
                             streams = self.mainProperties[x[-8:]].realLength
                         except:
                             logger.error('Could not find matching VariableLengthProp for stream {}'.format(x))
-                            streams = len(contents) // (2 if _type == '1002' else 4 if _type in ('1003', '1004') else 8 if type in ('1005', '1007', '1040') else 16)
+                            streams = len(contents) // (2 if _type == '1002' else 4 if _type in ('1003', '1004') else 8 if type in ('1005', '1007', '1014', '1040') else 16)
                     else:
                         raise NotImplementedError('The stream specified is of type {}. We don\'t currently understand exactly how this type works. If it is mandatory that you have the contents of this stream, please create an issue labled "NotImplementedError: _getTypedStream {}".'.format(_type, _type))
                     if _type in ('101F', '101E', '1102'):
@@ -249,7 +249,7 @@ class MSGFile(olefile.OleFileIO):
                             for y in range(streams):
                                 if self.Exists(x + '-' + properHex(y, 8), False):
                                     extras.append(self._getStream(x + '-' + properHex(y, 8), False))
-                    elif _type in ('1002', '1003', '1004', '1005', '1007', '1040', '1048'):
+                    elif _type in ('1002', '1003', '1004', '1005', '1007', '1014', '1040', '1048'):
                         extras = divide(contents, (2 if _type == '1002' else 4 if _type in ('1003', '1004') else 8 if type in ('1005', '1007', '1040') else 16))
                         contents = streams
                 return True, parseType(int(_type, 16), contents, self.stringEncoding, extras)


### PR DESCRIPTION
**v0.27.12**
* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Made an assumption about where an exception was thrown from and was wrong. While that location would have throw an exception, the function that called that code was the one to actually throw the exception in question. This issue *should* be fixed...
* [[TeamMsgExtractor #162](https://github.com/TeamMsgExtractor/msg-extractor/issues/162)] Made another attempt to fix the execution flag on the wrapper script.