### PR TITLE
Version 0.27.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.27.14**
+* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Fixed typo that I made in the last version that broke things. I didn't have the resources to test this one myself, unfortunately.
+* Fixed a typo in an exception message.
+
 **v0.27.13**
 * [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Moved some data used in checks into constants so that I can make sure they get changed every where that they are used. Hopefully I can close this issue.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.27.13**
+* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Moved some data used in checks into constants so that I can make sure they get changed every where that they are used. Hopefully I can close this issue.
+
 **v0.27.12**
 * [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Made an assumption about where an exception was thrown from and was wrong. While that location would have throw an exception, the function that called that code was the one to actually throw the exception in question. This issue *should* be fixed...
 * [[TeamMsgExtractor #162](https://github.com/TeamMsgExtractor/msg-extractor/issues/162)] Made another attempt to fix the execution flag on the wrapper script.

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.13-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.13/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.14-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.14/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.12-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.12/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.13-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.13/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
 __date__ = '2021-01-05'
-__version__ = '0.27.13'
+__version__ = '0.27.14'
 
 import logging
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
-__date__ = '2021-01-01'
-__version__ = '0.27.12'
+__date__ = '2021-01-05'
+__version__ = '0.27.13'
 
 import logging
 

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -118,6 +118,30 @@ VARIABLE_LENGTH_PROPS_STRING = (
     '1102',
 )
 
+# Multiple type properties that take up 2 bytes
+MULTIPLE_2_BYTES = (
+    '1002',
+)
+
+# Multiple type properties that take up 4 bytes
+MULTIPLE_4_BYTES = (
+    '1003',
+    '1004',
+)
+
+# Multiple type properties that take up 4 bytes
+MULTIPLE_8_BYTES = (
+    '1005',
+    '1007',
+    '1014',
+    '1040',
+)
+
+# Multiple type properties that take up 4 bytes
+MULTIPLE_16_BYTES = (
+
+)
+
 
 # This is a dictionary matching the code page number to it's encoding name.
 # The list used to make this can be found here:

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -241,7 +241,7 @@ class MSGFile(olefile.OleFileIO):
                             streams = self.mainProperties[x[-8:]].realLength
                         except:
                             logger.error('Could not find matching VariableLengthProp for stream {}'.format(x))
-                            streams = len(contents) // (2 if _type == '1002' else 4 if _type in ('1003', '1004') else 8 if type in ('1005', '1007', '1014', '1040') else 16)
+                            streams = len(contents) // (2 if _type in constants.MULTIPLE_2_BYTES else 4 if _type in constants.MULTIPLE_4_BYTES else 8 if type in constants.MULTIPLE_8_BYTES else 16)
                     else:
                         raise NotImplementedError('The stream specified is of type {}. We don\'t currently understand exactly how this type works. If it is mandatory that you have the contents of this stream, please create an issue labled "NotImplementedError: _getTypedStream {}".'.format(_type, _type))
                     if _type in ('101F', '101E', '1102'):
@@ -250,7 +250,7 @@ class MSGFile(olefile.OleFileIO):
                                 if self.Exists(x + '-' + properHex(y, 8), False):
                                     extras.append(self._getStream(x + '-' + properHex(y, 8), False))
                     elif _type in ('1002', '1003', '1004', '1005', '1007', '1014', '1040', '1048'):
-                        extras = divide(contents, (2 if _type == '1002' else 4 if _type in ('1003', '1004') else 8 if type in ('1005', '1007', '1040') else 16))
+                        extras = divide(contents, (2 if _type in constants.MULTIPLE_2_BYTES else 4 if _type in constants.MULTIPLE_4_BYTES else 8 if type in constants.MULTIPLE_8_BYTES else 16))
                         contents = streams
                 return True, parseType(int(_type, 16), contents, self.stringEncoding, extras)
         return False, None # We didn't find the stream.

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -241,7 +241,7 @@ class MSGFile(olefile.OleFileIO):
                             streams = self.mainProperties[x[-8:]].realLength
                         except:
                             logger.error('Could not find matching VariableLengthProp for stream {}'.format(x))
-                            streams = len(contents) // (2 if _type in constants.MULTIPLE_2_BYTES else 4 if _type in constants.MULTIPLE_4_BYTES else 8 if type in constants.MULTIPLE_8_BYTES else 16)
+                            streams = len(contents) // (2 if _type in constants.MULTIPLE_2_BYTES else 4 if _type in constants.MULTIPLE_4_BYTES else 8 if _type in constants.MULTIPLE_8_BYTES else 16)
                     else:
                         raise NotImplementedError('The stream specified is of type {}. We don\'t currently understand exactly how this type works. If it is mandatory that you have the contents of this stream, please create an issue labled "NotImplementedError: _getTypedStream {}".'.format(_type, _type))
                     if _type in ('101F', '101E', '1102'):
@@ -250,7 +250,7 @@ class MSGFile(olefile.OleFileIO):
                                 if self.Exists(x + '-' + properHex(y, 8), False):
                                     extras.append(self._getStream(x + '-' + properHex(y, 8), False))
                     elif _type in ('1002', '1003', '1004', '1005', '1007', '1014', '1040', '1048'):
-                        extras = divide(contents, (2 if _type in constants.MULTIPLE_2_BYTES else 4 if _type in constants.MULTIPLE_4_BYTES else 8 if type in constants.MULTIPLE_8_BYTES else 16))
+                        extras = divide(contents, (2 if _type in constants.MULTIPLE_2_BYTES else 4 if _type in constants.MULTIPLE_4_BYTES else 8 if _type in constants.MULTIPLE_8_BYTES else 16))
                         contents = streams
                 return True, parseType(int(_type, 16), contents, self.stringEncoding, extras)
         return False, None # We didn't find the stream.

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -476,7 +476,7 @@ def parseType(_type, stream, encoding, extras):
                 return tuple(constants.STMF64.unpack(x)[0] for x in extras)
             if _type == 0x1007:
                 values = tuple(constants.STMF64.unpack(x)[0] for x in extras)
-                raise NotImplementedError('Parsing for type 0x1007 has not yet een implmented. If you need this type, please create a new issue labeled "NotImplementedError: parseType 0x1007"')
+                raise NotImplementedError('Parsing for type 0x1007 has not yet been implmented. If you need this type, please create a new issue labeled "NotImplementedError: parseType 0x1007"')
             if _type == 0x1014:
                 return tuple(constants.STMI64.unpack(x)[0] for x in extras)
             if _type == 0x1040:


### PR DESCRIPTION
**v0.27.14**
* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] Fixed typo that I made in the last version that broke things. I didn't have the resources to test this one myself, unfortunately.
* Fixed a typo in an exception message.