### PR TITLE
v0.27.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.27.16**
+* [[TeamMsgExtractor #177](https://github.com/TeamMsgExtractor/msg-extractor/issues/177)] Fixed incorrect struct being used. It should be the correct one now, but further testing will be required to confirm this.
+* Fixed log error message in `extract_msg.prop` to actually format a value into the message.
+
 **v0.27.15**
 * [[TeamMsgExtractor #177](https://github.com/TeamMsgExtractor/msg-extractor/issues/177)] Fixed missing import.
 

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.15-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.27.15/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.27.16-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.27.16/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
-__date__ = '2021-01-05'
-__version__ = '0.27.15'
+__date__ = '2021-01-06'
+__version__ = '0.27.16'
 
 import logging
 

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -138,7 +138,7 @@ class FixedLengthProp(PropBase):
                 value = fromTimeStamp(msgEpoch(constants.ST3.unpack(value)[0]))
             except Exception as e:
                 logger.exception(e)
-                logger.error('Timestamp value of {} caused an exception. This was probably caused by the time stamp being too far in the future.')
+                logger.error('Timestamp value of {} caused an exception. This was probably caused by the time stamp being too far in the future.'.format(msgEpoch(constants.ST3.unpack(value)[0])))
                 logger.error(self.raw)
                 value = constants.ST3.unpack(value)[0]
         elif _type == 0x0048:  # PtypGuid

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -456,7 +456,7 @@ def parseType(_type, stream, encoding, extras):
             return ret
         elif _type == 0x1102:
             ret = copy.deepcopy(extras)
-            lengths = tuple(struct.unpack('<i', stream[pos*8:(pos+1)*8]) for pos in range(len(stream) // 8))
+            lengths = tuple(constants.STUI32.unpack(stream[pos*8:(pos+1)*8]) for pos in range(len(stream) // 8))
             length_lengths = len(lengths)
             if length_lengths > length_extras:
                 logger.warning('Error while parsing multiple type. Expected {} stream{}, got {}. Ignoring.'.format(length_lengths, 's' if length_lengths > 1 or length_lengths == 0 else '', length_extras))


### PR DESCRIPTION
**v0.27.16**
* [[TeamMsgExtractor #177](https://github.com/TeamMsgExtractor/msg-extractor/issues/177)] Fixed incorrect struct being used. It should be the correct one now, but further testing will be required to confirm this.
* Fixed log error message in `extract_msg.prop` to actually format a value into the message.