### PR TITLE
v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v0.28.2**
+* Started preparing more of the code for when HTML and RTF saving are fully implemented. Please note that they do not work at all right now. Commented out the code for this because it wasn't meant to be uncommented.
+* [[TeamMsgExtractor #184](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added code to ensure file names don't have null characters when saving an attachment.
+* Minor improvement to the section of the save code that checks if you have provided incompatible options.
+* [[TeamMsgExtractor #185](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added the `IncompatibleOptionsError`. It was supposed to be added a few updates ago, but was accidentally left out.
+* Modified `Message.save` to return the current `Message` instance to allow for chained commands. This allows you to do something like `extract_msg.openMsg("path/to/message.msg").save().close()` where you could not before.
+
 **v0.28.1**
 * [[TeamMsgExtractor #181](https://github.com/TeamMsgExtractor/msg-extractor/issues/181)] Fixed issue in `Attachment` that arose when moving some of the code to a base class.
 * Fixed small error in `utils.parse_type` that caused it to incorrectly compare expected and actual length. Fortunately, this had no actual effect aside from a warning.

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'The Elemental of Destruction & Matthew Walker'
-__date__ = '2021-01-12'
-__version__ = '0.28.1'
+__date__ = '2021-02-16'
+__version__ = '0.28.2'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -48,7 +48,7 @@ def main():
                         print(msg.body)
                     else:
                         os.chdir(out)
-                        msg.save(toJson = args.json, useFileName = args.use_filename, ContentId = args.cid)#, html = args.html, rtf = args.html)
+                        msg.save(toJson = args.json, useFileName = args.use_filename, ContentId = args.cid)#, html = args.html, rtf = args.html, args.allowFallback)
             except Exception as e:
                 print("Error with file '" + x[0] + "': " +
                       traceback.format_exc())

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -7,7 +7,7 @@ from extract_msg.attachment_base import AttachmentBase
 from extract_msg.named import NamedAttachmentProperties
 from extract_msg.prop import FixedLengthProp, VariableLengthProp
 from extract_msg.properties import Properties
-from extract_msg.utils import openMsg, verifyPropertyId, verifyType
+from extract_msg.utils import openMsg, inputToString, verifyPropertyId, verifyType
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -48,8 +48,8 @@ class Attachment(AttachmentBase):
         else:
             raise TypeError('Unknown attachment type.')
 
-    def save(self, contentId = False, json = False, useFileName = False, raw = False, customPath = None, customFilename = None,
-             html = False, rtf = False):
+    def save(self, contentId = False, json = False, useFileName = False, raw = False, customPath = None,
+             customFilename = None):#, html = False, rtf = False, allowFallback = False):
         # Check if the user has specified a custom filename
         filename = None
         if customFilename is not None and customFilename != '':
@@ -76,20 +76,23 @@ class Attachment(AttachmentBase):
                 customPath += '/'
             filename = customPath + filename
 
+        # Someone managed to have a null character here, so let's get rid of that
+        filename = inputToString(filename, self.msg.stringEncoding).replace('\x00', '')
+
         if self.__type == "data":
             with open(filename, 'wb') as f:
                 f.write(self.__data)
         else:
-            self.saveEmbededMessage(contentId, json, useFileName, raw, customPath, customFilename, html, rtf)
+            self.saveEmbededMessage(contentId, json, useFileName, raw, customPath, customFilename)#, html, rtf, allowFallback)
         return filename
 
     def saveEmbededMessage(self, contentId = False, json = False, useFileName = False, raw = False, customPath = None,
-                           customFilename = None, html = False, rtf = False):
+                           customFilename = None):#, html = False, rtf = False, allowFallback = False):
         """
         Seperate function from save to allow it to
         easily be overridden by a subclass.
         """
-        self.data.save(json, useFileName, raw, contentId, customPath, customFilename, html, rtf)
+        self.data.save(json, useFileName, raw, contentId, customPath, customFilename)#, html, rtf, allowFallback)
 
     @property
     def cid(self):

--- a/extract_msg/exceptions.py
+++ b/extract_msg/exceptions.py
@@ -18,6 +18,17 @@ class ConversionError(Exception):
     """
     pass
 
+class DataNotFoundError(Exception):
+    """
+    Requested stream type was unavailable.
+    """
+    pass
+
+class IncompatibleOptionsError(Exception):
+    """
+    Provided options are incompatible with each other.
+    """
+
 class InvalidFileFormatError(OSError):
     """
     An Invalid File Format Error occurred.

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -16,7 +16,7 @@ import tzlocal
 
 from extract_msg import constants
 from extract_msg.compat import os_ as os
-from extract_msg.exceptions import ConversionError, InvaildPropertyIdError, UnknownCodepageError, UnknownTypeError, UnrecognizedMSGTypeError
+from extract_msg.exceptions import ConversionError, IncompatibleOptionsError, InvaildPropertyIdError, UnknownCodepageError, UnknownTypeError, UnrecognizedMSGTypeError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -165,7 +165,7 @@ def get_command_args(args):
                         help='Changes to write output files as json.')
     # --file-logging
     parser.add_argument('--file-logging', dest='file_logging', action='store_true',
-                        help='Enables file logging. Implies --verbose')
+                        help='Enables file logging. Implies --verbose.')
     # --verbose
     parser.add_argument('--verbose', dest='verbose', action='store_true',
                         help='Turns on console logging.')
@@ -186,13 +186,16 @@ def get_command_args(args):
                         help='Tells the program to dump the message body (plain text) to stdout. Overrides saving arguments.')
     # --html
     #parser.add_argument('--html', dest='html', action='store_true',
-    #                    help='Sets whether the output should be html. If this is not possible, will fallback to plain text')
+    #                    help='Sets whether the output should be html. If this is not possible, will error.')
     # --rtf
     #parser.add_argument('--rtf', dest='rtf', action='store_true',
-    #                    help='Sets whether the output should be rtf. If this is not possible, will fallback to plain text')
+    #                    help='Sets whether the output should be rtf. If this is not possible, will error.')
+    # --allow-fallback
+    #parser.add_argument('--allow-fallback', dest='allowFallbac', action='store_true',
+    #                    help='Tells the program to fallback to a different save type if the selected one is not possible.')
     # --out-name NAME
     # parser.add_argument('--out-name', dest = 'out_name',
-    #                     help = 'Name to be used with saving the file output. Should come immediately after the file name')
+    #                     help = 'Name to be used with saving the file output. Should come immediately after the file name.')
     # [msg files]
     parser.add_argument('msgs', metavar='msg', nargs='+',
                         help='An msg file to be parsed')
@@ -207,7 +210,7 @@ def get_command_args(args):
     #if options.json:
     #    valid += 1
     #if valid > 1:
-    #    raise Exception('Only one of these options may be selected at a time: --html, --rtf, --json')
+    #    raise IncompatibleOptionsError('Only one of these options may be selected at a time: --html, --rtf, --json')
 
     if options.dev or options.file_logging:
         options.verbose = True


### PR DESCRIPTION
**v0.28.2**
* Started preparing more of the code for when HTML and RTF saving are fully implemented. Please note that they do not work at all right now. Commented out the code for this because it wasn't meant to be uncommented.
* [[TeamMsgExtractor #184](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added code to ensure file names don't have null characters when saving an attachment.
* Minor improvement to the section of the save code that checks if you have provided incompatible options.
* [[TeamMsgExtractor #185](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added the `IncompatibleOptionsError`. It was supposed to be added a few updates ago, but was accidentally left out.
* Modified `Message.save` to return the current `Message` instance to allow for chained commands. This allows you to do something like `extract_msg.openMsg("path/to/message.msg").save().close()` where you could not before.