### PR TITLE
v0.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.28.4**
+* [[TeamMsgExtractor #184](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added code to `Message` to ensure subjects with null characters get stripped of them.
+* Moved code for stripping subjects of bad characters to `prepareFilename` in `utils`.
+
 **v0.28.3**
 * Fixed minor typo in an exception description.
 * Updated the README this time. Forgot to do it for at least 1 update.

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.3-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.28.3/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.4-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.28.4/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -26,9 +26,9 @@ https://github.com/mattgwwalker/msg-extractor
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__author__ = 'The Elemental of Destruction & Matthew Walker'
-__date__ = '2021-02-16'
-__version__ = '0.28.3'
+__author__ = 'Destiny Peterson & Matthew Walker'
+__date__ = '2021-02-18'
+__version__ = '0.28.4'
 
 import logging
 

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -77,7 +77,7 @@ class Attachment(AttachmentBase):
             filename = customPath + filename
 
         # Someone managed to have a null character here, so let's get rid of that
-        filename = inputToString(filename, self.msg.stringEncoding).replace('\x00', '')
+        filename = prepareFilename(inputToString(filename, self.msg.stringEncoding))
 
         if self.__type == "data":
             with open(filename, 'wb') as f:

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -13,7 +13,7 @@ from extract_msg.compat import os_ as os
 from extract_msg.exceptions import DataNotFoundError, IncompatibleOptionsError
 from extract_msg.message_base import MessageBase
 from extract_msg.recipient import Recipient
-from extract_msg.utils import addNumToDir, inputToBytes, inputToString
+from extract_msg.utils import addNumToDir, inputToBytes, inputToString, prepareFilename
 
 
 
@@ -97,7 +97,7 @@ class Message(MessageBase):
                 if self.subject is None:
                     subject = '[No subject]'
                 else:
-                    subject = ''.join(i for i in self.subject if i not in r'\/:*?"<>|')
+                    subject = prepareFilename(self.subject)
 
                 dirName = dirName + ' ' + subject
 

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -143,6 +143,14 @@ def divide(string, length):
     """
     return [string[length * x:length * (x + 1)] for x in range(int(ceilDiv(len(string), length)))]
 
+def prepareFilename(filename):
+    """
+    Adjusts :param filename: so that it can succesfully be used as an actual
+    file name.
+    """
+    # I would use re here, but it tested to be slightly slower than this.
+    return ''.join(i for i in filename if i not in r'\/:*?"<>|' + '\x00')
+
 def fromTimeStamp(stamp):
     return datetime.datetime.fromtimestamp(stamp, tzlocal.get_localzone())
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     long_description_content_type='text/x-rst',
     url=github_url,
     download_url='%s/archives/master' % github_url,
-    author='The Elemental of Destruction & Matthew Walker',
+    author='Destiny Peterson & Matthew Walker',
     author_email='arceusthe@gmail.com, mattgwwalker@gmail.com',
     license='GPL',
     packages=[main_module],


### PR DESCRIPTION
**v0.28.4**
* [[TeamMsgExtractor #184](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added code to `Message` to ensure subjects with null characters get stripped of them.
* Moved code for stripping subjects of bad characters to `prepareFilename` in `utils`.