### PR TITLE
v0.28.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.28.5**
+* [[TeamMsgExtractor #189](https://github.com/TeamMsgExtractor/msg-extractor/issues/189)] Forgot to import `prepareFilename` in `attachment.py`.
+* Fixed bad link in the changelog.
+
 **v0.28.4**
 * [[TeamMsgExtractor #184](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added code to `Message` to ensure subjects with null characters get stripped of them.
 * Moved code for stripping subjects of bad characters to `prepareFilename` in `utils`.
@@ -10,7 +14,7 @@
 * Started preparing more of the code for when HTML and RTF saving are fully implemented. Please note that they do not work at all right now. Commented out the code for this because it wasn't meant to be uncommented.
 * [[TeamMsgExtractor #184](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added code to ensure file names don't have null characters when saving an attachment.
 * Minor improvement to the section of the save code that checks if you have provided incompatible options.
-* [[TeamMsgExtractor #185](https://github.com/TeamMsgExtractor/msg-extractor/issues/184)] Added the `IncompatibleOptionsError`. It was supposed to be added a few updates ago, but was accidentally left out.
+* [[TeamMsgExtractor #185](https://github.com/TeamMsgExtractor/msg-extractor/issues/185)] Added the `IncompatibleOptionsError`. It was supposed to be added a few updates ago, but was accidentally left out.
 * Modified `Message.save` to return the current `Message` instance to allow for chained commands. This allows you to do something like `extract_msg.openMsg("path/to/message.msg").save().close()` where you could not before.
 
 **v0.28.1**

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Credits
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.4-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.28.4/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.5-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.28.5/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2021-02-18'
-__version__ = '0.28.4'
+__date__ = '2021-02-19'
+__version__ = '0.28.5'
 
 import logging
 

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -7,7 +7,7 @@ from extract_msg.attachment_base import AttachmentBase
 from extract_msg.named import NamedAttachmentProperties
 from extract_msg.prop import FixedLengthProp, VariableLengthProp
 from extract_msg.properties import Properties
-from extract_msg.utils import openMsg, inputToString, verifyPropertyId, verifyType
+from extract_msg.utils import openMsg, inputToString, prepareFilename, verifyPropertyId, verifyType
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
**v0.28.5**
* [[TeamMsgExtractor #189](https://github.com/TeamMsgExtractor/msg-extractor/issues/189)] Forgot to import `prepareFilename` in `attachment.py`.
* Fixed bad link in the changelog.