### PR TITLE
v0.28.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ logging.json
 # Developer files
 upload.bat
 upload.sh
+venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **v0.28.5**
 * [[TeamMsgExtractor #191](https://github.com/TeamMsgExtractor/msg-extractor/issues/191)] This feature was never properly implemented, so it's not officially supported. However, this specific issue should be fixed. This is a temporary patch until I can get around to rewriting the way the module saves files in general.
 * Added `venv` to the .gitignore list.
+* Added information to the readme.
 
 **v0.28.5**
 * [[TeamMsgExtractor #189](https://github.com/TeamMsgExtractor/msg-extractor/issues/189)] Forgot to import `prepareFilename` in `attachment.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 **v0.28.5**
+* [[TeamMsgExtractor #191](https://github.com/TeamMsgExtractor/msg-extractor/issues/191)] This feature was never properly implemented, so it's not officially supported. However, this specific issue should be fixed. This is a temporary patch until I can get around to rewriting the way the module saves files in general.
+* Added `venv` to the .gitignore list.
+
+**v0.28.5**
 * [[TeamMsgExtractor #189](https://github.com/TeamMsgExtractor/msg-extractor/issues/189)] Forgot to import `prepareFilename` in `attachment.py`.
 * Fixed bad link in the changelog.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**v0.28.5**
+**v0.28.6**
 * [[TeamMsgExtractor #191](https://github.com/TeamMsgExtractor/msg-extractor/issues/191)] This feature was never properly implemented, so it's not officially supported. However, this specific issue should be fixed. This is a temporary patch until I can get around to rewriting the way the module saves files in general.
 * Added `venv` to the .gitignore list.
 * Added information to the readme.

--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,8 @@ Credits
 
 `Dean Malmgren`_ - First implementation of the setup.py script
 
+And thank you to everyone who has opened an issue and helped us track down those pesky bugs.
+
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,19 @@ Extracts emails and attachments saved in Microsoft Outlook's .msg files
 The python package extract_msg automates the extraction of key email
 data (from, to, cc, date, subject, body) and the email's attachments.
 
+NOTICE
+======
+0.29.* will be the last versions that will support Python 2. While we want to
+continue to support it, it would just be too much work to do so. We are
+providing notice ahead of time of this change so that you may sort out your
+Python environments ahead of time.
+
+This module has a Discord server for general discussion. You can find it here:
+`Discord`_
+
+
+Changelog
+---------
 -  `Changelog <CHANGELOG.md>`__
 
 Usage
@@ -182,8 +195,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.5-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.28.5/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.6-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.28.6/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/
@@ -195,3 +208,4 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. _Philippe Lagadec: https://github.com/decalage2
 .. _Dean Malmgren: https://github.com/deanmalmgren
 .. _Joel Kaufman: https://github.com/joelkaufman
+.. _Discord: https://discord.com/invite/B77McRmzdc

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2021-02-19'
-__version__ = '0.28.5'
+__date__ = '2021-03-02'
+__version__ = '0.28.6'
 
 import logging
 

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -71,13 +71,13 @@ class Attachment(AttachmentBase):
                            ''.join(random.choice(string.ascii_uppercase + string.digits)
                                    for _ in range(5)) + '.bin'
 
+        # Someone managed to have a null character here, so let's get rid of that
+        filename = prepareFilename(inputToString(filename, self.msg.stringEncoding))
+
         if customPath is not None and customPath != '':
             if customPath[-1] != '/' or customPath[-1] != '\\':
                 customPath += '/'
             filename = customPath + filename
-
-        # Someone managed to have a null character here, so let's get rid of that
-        filename = prepareFilename(inputToString(filename, self.msg.stringEncoding))
 
         if self.__type == "data":
             with open(filename, 'wb') as f:


### PR DESCRIPTION
**v0.28.6**
* [[TeamMsgExtractor #191](https://github.com/TeamMsgExtractor/msg-extractor/issues/191)] This feature was never properly implemented, so it's not officially supported. However, this specific issue should be fixed. This is a temporary patch until I can get around to rewriting the way the module saves files in general.
* Added `venv` to the .gitignore list.
* Added information to the readme.