### PR TITLE
v0.28.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v0.28.7**
+* Added hex versions of the `MULTIPLE_X_BYTES` constants.
+* Added `1048` to `constants.MULTIPLE_16_BYTES`
+* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] rewrote the parsing of the length in `VariableLengthProp.__init__` to use constants rather than values coded directly into the function. This should fix this issue.
+
 **v0.28.6**
 * [[TeamMsgExtractor #191](https://github.com/TeamMsgExtractor/msg-extractor/issues/191)] This feature was never properly implemented, so it's not officially supported. However, this specific issue should be fixed. This is a temporary patch until I can get around to rewriting the way the module saves files in general.
 * Added `venv` to the .gitignore list.

--- a/README.rst
+++ b/README.rst
@@ -195,8 +195,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.6-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.28.6/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.28.7-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.28.7/
 
 .. |PyPI1| image:: https://img.shields.io/badge/python-2.7+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-2715/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2021-03-02'
-__version__ = '0.28.6'
+__version__ = '0.28.7'
 
 import logging
 

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -125,10 +125,19 @@ MULTIPLE_2_BYTES = (
     '1002',
 )
 
+MULTIPLE_2_BYTES_HEX = (
+    0x1002,
+)
+
 # Multiple type properties that take up 4 bytes
 MULTIPLE_4_BYTES = (
     '1003',
     '1004',
+)
+
+MULTIPLE_4_BYTES_HEX = (
+    0x1003,
+    0x1004,
 )
 
 # Multiple type properties that take up 4 bytes
@@ -139,9 +148,20 @@ MULTIPLE_8_BYTES = (
     '1040',
 )
 
+MULTIPLE_8_BYTES_HEX = (
+    0x1005,
+    0x1007,
+    0x1014,
+    0x1040,
+)
+
 # Multiple type properties that take up 4 bytes
 MULTIPLE_16_BYTES = (
+    '1048'
+)
 
+MULTIPLE_16_BYTES_HEX = (
+    0x1048
 )
 
 

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -157,11 +157,11 @@ MULTIPLE_8_BYTES_HEX = (
 
 # Multiple type properties that take up 4 bytes
 MULTIPLE_16_BYTES = (
-    '1048'
+    '1048',
 )
 
 MULTIPLE_16_BYTES_HEX = (
-    0x1048
+    0x1048,
 )
 
 

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -166,13 +166,13 @@ class VariableLengthProp(PropBase):
             self.__realLength = self.__length - 1
         elif self.type == 0x001F:
             self.__realLength = self.__length - 2
-        elif self.type == 0x1002:
+        elif self.type in constants.MULTIPLE_2_BYTES_HEX:
             self.__realLength = self.__length // 2
-        elif self.type in (0x1003, 0x1004):
+        elif self.type in constants.MULTIPLE_4_BYTES_HEX:
             self.__realLength = self.__length // 4
-        elif self.type in (0x1005, 0x1007, 0x1040):
+        elif self.type in constants.MULTIPLE_8_BYTES_HEX:
             self.__realLength = self.__length // 8
-        elif self.type == 0x1048:
+        elif self.type in constants.MULTIPLE_16_BYTES_HEX:
             self.__realLength = self.__length // 16
         elif self.type == 0x000D:
             self.__realLength = None


### PR DESCRIPTION
**v0.28.7**
* Added hex versions of the `MULTIPLE_X_BYTES` constants.
* Added `1048` to `constants.MULTIPLE_16_BYTES`
* [[TeamMsgExtractor #173](https://github.com/TeamMsgExtractor/msg-extractor/issues/173)] rewrote the parsing of the length in `VariableLengthProp.__init__` to use constants rather than values coded directly into the function. This should fix this issue.