### PR TITLE
Version 0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
+**v0.30.1**
+* Added property `MessageBase.htmlBodyPrepared` which provides the HTML body that has been prepared for actual use or conversion to PDF. All attachments that can be injected into the body directly will be injected.
+* Corrected a mistake in the documentation of `Message.save`.
+* Fixed issue where the command line parser was not checking for raw in conjunction with other saving options.
+* Changed `utils.setupLogging` to use `pathlib`.
+* Improved reliability of the logic in `utils.setupLogging`.
+* Removed function `utils.getContFileDir`.
+* Cleaned up plain `Exception` being raised at the end of `utils.injectRtfHeader` if the injection failed. This now raises `RuntimeError`, an error that should be reported so the injection system can be improved.
+* Added parsing for PtypServerId to `utils.parseType`.
+* Added `FolderID`, `MessageID`, and `ServerID` to `data`.
+* Added zip output to the command line.
+* Added support for PtypMultipleFloatingTime to `utils.parseType`.
+* Improved documentation of many functions with the exceptions they may raise.
+* Changed the way zipfiles are handled so that files written to them actually have a modification date now.
+
 **v0.30.0**
 * Removed all support for Python 2. This caused a lot of things to be moved around and changed from indirect references to direct references, so it's possible something fell through the cracks. I'm doing my best to test it, but let me know if you have an issue.
-* Changed classes to now prefer super() over direct superclass initialization.
+* Changed classes to now prefer `super()` over direct superclass initialization.
 * Removed explicit object subclassing (it's implicit in Python 3 so we don't need it anymore).
 * Converted most `.format`s into f strings.
 * Improved consistency of docstrings. It's not perfect, but it should at least be better.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **v0.30.1**
-* Added property `MessageBase.htmlBodyPrepared` which provides the HTML body that has been prepared for actual use or conversion to PDF. All attachments that can be injected into the body directly will be injected.
+* [[TeamMsgExtractor #102](https://github.com/TeamMsgExtractor/msg-extractor/issues/102)] Added property `MessageBase.htmlBodyPrepared` which provides the HTML body that has been prepared for actual use or conversion to PDF. All attachments that can be injected into the body directly will be injected.
 * Corrected a mistake in the documentation of `Message.save`.
 * Fixed issue where the command line parser was not checking for raw in conjunction with other saving options.
 * Changed `utils.setupLogging` to use `pathlib`.
@@ -11,7 +11,7 @@
 * Added zip output to the command line.
 * Added support for PtypMultipleFloatingTime to `utils.parseType`.
 * Improved documentation of many functions with the exceptions they may raise.
-* Changed the way zipfiles are handled so that files written to them actually have a modification date now.
+* Changed the way zip files are handled so that files written to them actually have a modification date now.
 
 **v0.30.0**
 * Removed all support for Python 2. This caused a lot of things to be moved around and changed from indirect references to direct references, so it's possible something fell through the cracks. I'm doing my best to test it, but let me know if you have an issue.

--- a/README.rst
+++ b/README.rst
@@ -138,8 +138,9 @@ Error Reporting
 
 Should you encounter an error that has not already been reported, please
 do the following when reporting it: \* Make sure you are using the
-latest version of extract_msg. \* State your Python version. \* Include
-the code, if any, that you used. \* Include a copy of the traceback.
+latest version of extract_msg (check the version on PyPi). \* State your
+Python version. \* Include the code, if any, that you used. \* Include a
+copy of the traceback.
 
 Installation
 ------------
@@ -205,8 +206,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.1-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-01-19'
-__version__ = '0.30.0'
+__date__ = '2022-01-26'
+__version__ = '0.30.1'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -15,12 +15,15 @@ def main() -> None:
 
     # Determine where to save the files to.
     currentDir = os.getcwd() # Store this incase the path changes.
-    if args.out_path:
-        if not os.path.exists(args.out_path):
-            os.makedirs(args.out_path)
-        out = args.out_path
+    if not args.zip:
+        if args.out_path:
+            if not os.path.exists(args.out_path):
+                os.makedirs(args.out_path)
+            out = args.out_path
+        else:
+            out = currentDir
     else:
-        out = currentDir
+        out = args.out_path if args.out_path else ''
 
     if args.dev:
         import extract_msg.dev
@@ -54,6 +57,8 @@ def main() -> None:
             'html': args.html,
             'rtf': args.rtf,
             'allowFallback': args.allowFallback,
+            'preparedHtml': args.preparedHtml,
+            'zip': args.zip,
         }
 
         for x in args.msgs:

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -10,7 +10,7 @@ from .attachment_base import AttachmentBase
 from .named import NamedAttachmentProperties
 from .prop import FixedLengthProp, VariableLengthProp
 from .properties import Properties
-from .utils import openMsg, inputToString, prepareFilename, verifyPropertyId, verifyType
+from .utils import createZipOpen, inputToString, openMsg, prepareFilename, verifyPropertyId, verifyType
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -133,7 +133,6 @@ class Attachment(AttachmentBase):
         # Check if we are doing a zip file.
         _zip = kwargs.get('zip')
 
-
         # ZipFile handling.
         if _zip:
             # If we are doing a zip file, first check that we have been given a path.
@@ -147,7 +146,7 @@ class Attachment(AttachmentBase):
             # Path needs to be done in a special way if we are in a zip file.
             customPath = pathlib.Path(kwargs.get('customPath', ''))
             # Set the open command to be that of the zip file.
-            _open = _zip.open
+            _open = createZipOpen(_zip.open)
             # Zip files use w for writing in binary.
             mode = 'w'
         else:
@@ -200,7 +199,6 @@ class Attachment(AttachmentBase):
                 _zip.close()
 
             return self.msg
-
 
     def saveEmbededMessage(self, **kwargs):
         """

--- a/extract_msg/data.py
+++ b/extract_msg/data.py
@@ -1,8 +1,65 @@
 """
-Various small data structures used in msg extractor.
+Various small data structures used in extract_msg.
 """
 
 from . import constants
+
+
+class FolderID:
+    """
+    A Folder ID structure specified in [MS-OXCDATA].
+    """
+    def __init__(self, data : bytes):
+        self.__replicaID = constants.STUI16.unpack(data[:2])
+        # This entry is 6 bytes, so we pull some shenanigans to unpack it.
+        self.__globalCounter = constants.STUI64.unpack(data[2:8] + b'\x00\x00')
+
+    @property
+    def globalCounter(self) -> int:
+        """
+        An unsigned ineger identifying the folder within its Store object.
+        """
+        return self.__globalCounter
+
+    @property
+    def replicaID(self) -> int:
+        """
+        An unsigned integer identifying a Store object.
+        """
+        return self.__replicaID
+
+
+
+class MessageID:
+    """
+
+    """
+    def __init__(self, data):
+        self.__replicaID = constants.STUI16.unpack(data[:2])
+        # This entry is 6 bytes, so we pull some shenanigans to unpack it.
+        self.__globalCounter = constants.STUI64.unpack(data[2:8] + b'\x00\x00')
+
+    @property
+    def globalCounter(self) -> int:
+        """
+        An unsigned ineger identifying the folder within its Store object.
+        """
+        return self.__globalCounter
+
+    @property
+    def isFolder(self) -> bool:
+        """
+        Tells if the object pointed to is actually a folder.
+        """
+        return self.__globalCounter == 0 and self.__replicaID == 0
+
+    @property
+    def replicaID(self) -> int:
+        """
+        An unsigned integer identifying a Store object.
+        """
+        return self.__replicaID
+
 
 
 class PermanentEntryID:
@@ -42,3 +99,55 @@ class PermanentEntryID:
         Returns the provider UID.
         """
         return self.__providerUID
+
+
+
+class ServerID:
+    """
+    Class representing a PtypServerId.
+    """
+    def __init__(self, data : bytes):
+        """
+        :param data: The data to use to create the ServerID.
+
+        :raises TypeError: if the data is not a ServerID.
+        """
+        # According to the docs, the first byte being a 1 means it follows this
+        # structure. A value of 0 means it does not.
+        if data[0] != 1:
+            raise TypeError('Not a standard ServerID.')
+        self.__raw = data
+        self.__folderID = FolderID(data[1:9])
+        self.__messageID = MessageID(data[9:17])
+        self.__instance = constants.STUI32.unpack(data[17:21])
+
+    @property
+    def folderID(self) -> FolderID:
+        """
+        The folder the message will be in.
+        """
+        return self.__folderID
+
+    @property
+    def instance(self) -> int:
+        """
+        Instance number that is only used in multivalue properties for searching
+        for a specific ServerID. Will otherwise be 0.
+        """
+        return self.__instance
+
+    @property
+    def messageID(self) -> MessageID:
+        """
+        A MessageID identifying a message in a folder identified by the folderID
+        instance of this object. If the object pointed to is a folder, both
+        properties will be 0.
+        """
+        return self.__messageID
+
+    @property
+    def raw(self) -> bytes:
+        """
+        The raw data used to create this object.
+        """
+        return self.__raw

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ olefile>=0.46
 tzlocal>=2.1
 compressed_rtf>=1.0.6
 ebcdic>=1.1.1
+beautifulsoup4>=4.10.0


### PR DESCRIPTION
**v0.30.1**
* [[TeamMsgExtractor #102](https://github.com/TeamMsgExtractor/msg-extractor/issues/102)] Added property `MessageBase.htmlBodyPrepared` which provides the HTML body that has been prepared for actual use or conversion to PDF. All attachments that can be injected into the body directly will be injected.
* Corrected a mistake in the documentation of `Message.save`.
* Fixed issue where the command line parser was not checking for raw in conjunction with other saving options.
* Changed `utils.setupLogging` to use `pathlib`.
* Improved reliability of the logic in `utils.setupLogging`.
* Removed function `utils.getContFileDir`.
* Cleaned up plain `Exception` being raised at the end of `utils.injectRtfHeader` if the injection failed. This now raises `RuntimeError`, an error that should be reported so the injection system can be improved.
* Added parsing for PtypServerId to `utils.parseType`.
* Added `FolderID`, `MessageID`, and `ServerID` to `data`.
* Added zip output to the command line.
* Added support for PtypMultipleFloatingTime to `utils.parseType`.
* Improved documentation of many functions with the exceptions they may raise.
* Changed the way zip files are handled so that files written to them actually have a modification date now.