### PR TITLE
Fixed typo in string method call

### DIFF
--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -457,7 +457,7 @@ def knownMsgClass(classType : str) -> bool:
         return True
 
     for item in constants.KNOWN_CLASS_TYPES:
-        if classType.startsWith(item):
+        if classType.startswith(item):
             return True
 
     return False


### PR DESCRIPTION
Changed from startsWith to startswith
