### PR TITLE
Version 0.30.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.30.3**
+* Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.
+
 **v0.30.2**
 * Fixed typo in `utils.knownMsgClass`.
 * Updated contributing guidelines and pull request template. Pull requests were updated to match the new structure of the module while the guidelines were updated for clarity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **v0.30.3**
-* Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.
+* [[TeamMsgExtractor #232](https://github.com/TeamMsgExtractor/msg-extractor/issues/232)] Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.
 
 **v0.30.2**
 * Fixed typo in `utils.knownMsgClass`.

--- a/README.rst
+++ b/README.rst
@@ -206,8 +206,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.2-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.2/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.3-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.3/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-01-27'
-__version__ = '0.30.2'
+__date__ = '2022-01-28'
+__version__ = '0.30.3'
 
 import logging
 

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -306,15 +306,17 @@ KNOWN_CLASS_TYPES = (
     'ipm.distlist',
     'ipm.document',
     'ipm.ole.class',
+    'ipm.outlook.recall',
     'ipm.note',
     'ipm.post',
     'ipm.stickynote',
     'ipm.recall.report',
+    'ipm.remote',
     'ipm.report',
     'ipm.resend',
     'ipm.schedule',
     'ipm.task',
-    'ipm.taskrequest'
+    'ipm.taskrequest',
     'report',
 )
 


### PR DESCRIPTION
**v0.30.3**
* [[TeamMsgExtractor #232](https://github.com/TeamMsgExtractor/msg-extractor/issues/232)] Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.