### PR TITLE
v0.30.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.30.4**
+* [[TeamMsgExtractor #233](https://github.com/TeamMsgExtractor/msg-extractor/issues/233)] Added option to `Message.save` to only save the attachments (`attachmentsOnly`). This can also be used from the command line with the option `--attachments-only`.
+* Corrected error string for incompatible options in `Message.save`.
+
 **v0.30.3**
 * [[TeamMsgExtractor #232](https://github.com/TeamMsgExtractor/msg-extractor/issues/232)] Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 **v0.30.4**
 * [[TeamMsgExtractor #233](https://github.com/TeamMsgExtractor/msg-extractor/issues/233)] Added option to `Message.save` to only save the attachments (`attachmentsOnly`). This can also be used from the command line with the option `--attachments-only`.
 * Corrected error string for incompatible options in `Message.save`.
-* Fixed if blocks being nested weirdly in `Message.save` instead of being chained with elif. Probably an artifact left from adding support for html and rtf.
+* Fixed if blocks being nested weirdly in `Message.save` instead of being chained with `elif`. Probably an artifact left from adding support for HTML and RTF.
 
 **v0.30.3**
 * [[TeamMsgExtractor #232](https://github.com/TeamMsgExtractor/msg-extractor/issues/232)] Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **v0.30.4**
 * [[TeamMsgExtractor #233](https://github.com/TeamMsgExtractor/msg-extractor/issues/233)] Added option to `Message.save` to only save the attachments (`attachmentsOnly`). This can also be used from the command line with the option `--attachments-only`.
 * Corrected error string for incompatible options in `Message.save`.
+* Fixed if blocks being nested weirdly in `Message.save` instead of being chained with elif. Probably an artifact left from adding support for html and rtf.
 
 **v0.30.3**
 * [[TeamMsgExtractor #232](https://github.com/TeamMsgExtractor/msg-extractor/issues/232)] Updated list of known MSG class types so the module would correctly give `UnsupportedMSGTypeError` instead of `UnrecognizedMSGTypeError`.

--- a/README.rst
+++ b/README.rst
@@ -206,8 +206,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.3-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.3/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.4-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.4/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2022-01-28'
-__version__ = '0.30.3'
+__version__ = '0.30.4'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -49,15 +49,16 @@ def main() -> None:
 
         # Quickly make a dictionary for the keyword arguments.
         kwargs = {
-            'customPath': out,
-            'customFilename': args.out_name,
-            'json': args.json,
-            'useMsgFilename': args.use_filename,
-            'contentId': args.cid,
-            'html': args.html,
-            'rtf': args.rtf,
             'allowFallback': args.allowFallback,
+            'attachmentsOnly': args.attachmentsOnly,
+            'contentId': args.cid,
+            'customFilename': args.out_name,
+            'customPath': out,
+            'html': args.html,
+            'json': args.json,
             'preparedHtml': args.preparedHtml,
+            'rtf': args.rtf,
+            'useMsgFilename': args.use_filename,
             'zip': args.zip,
         }
 

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -249,26 +249,25 @@ class Message(MessageBase):
                         emailObj['attachments'] = attachmentNames
 
                         f.write(inputToBytes(json.dumps(emailObj), 'utf-8'))
+                    elif useHtml:
+                        # Inject the header into the data and then write it to
+                        # the file.
+                        data = injectHtmlHeader(self, prepared = kwargs.get('preparedHtml', False))
+                        f.write(data)
+                    elif useRtf:
+                        # Inject the header into the data and then write it to
+                        # the file.
+                        data = injectRtfHeader(self)
+                        f.write(data)
                     else:
-                        if useHtml:
-                            # Inject the header into the data and then write it
-                            # to the file.
-                            data = injectHtmlHeader(self, prepared = kwargs.get('preparedHtml', False))
-                            f.write(data)
-                        elif useRtf:
-                            # Inject the header into the data and then write it
-                            # to the file.
-                            data = injectRtfHeader(self)
-                            f.write(data)
-                        else:
-                            f.write(b'From: ' + inputToBytes(self.sender, 'utf-8') + crlf)
-                            f.write(b'To: ' + inputToBytes(self.to, 'utf-8') + crlf)
-                            f.write(b'Cc: ' + inputToBytes(self.cc, 'utf-8') + crlf)
-                            f.write(b'Bcc: ' + inputToBytes(self.bcc, 'utf-8') + crlf)
-                            f.write(b'Subject: ' + inputToBytes(self.subject, 'utf-8') + crlf)
-                            f.write(b'Date: ' + inputToBytes(self.date, 'utf-8') + crlf)
-                            f.write(b'-----------------' + crlf + crlf)
-                            f.write(inputToBytes(self.body, 'utf-8'))
+                        f.write(b'From: ' + inputToBytes(self.sender, 'utf-8') + crlf)
+                        f.write(b'To: ' + inputToBytes(self.to, 'utf-8') + crlf)
+                        f.write(b'Cc: ' + inputToBytes(self.cc, 'utf-8') + crlf)
+                        f.write(b'Bcc: ' + inputToBytes(self.bcc, 'utf-8') + crlf)
+                        f.write(b'Subject: ' + inputToBytes(self.subject, 'utf-8') + crlf)
+                        f.write(b'Date: ' + inputToBytes(self.date, 'utf-8') + crlf)
+                        f.write(b'-----------------' + crlf + crlf)
+                        f.write(inputToBytes(self.body, 'utf-8'))
 
         except Exception:
             if not _zip:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -197,6 +197,9 @@ def getCommandArgs(args):
     # --zip
     parser.add_argument('--zip', dest='zip',
                         help='Path to use for saving to a zip file.')
+    # --attachments-only
+    parser.add_argument('--attachments-only', dest='attachmentsOnly', action='store_true',
+                        help='Specify to only save attachments from an msg file.')
     # --out-name NAME
     parser.add_argument('--out-name', dest='out_name',
                         help='Name to be used with saving the file output. Should come immediately after the file name.')
@@ -207,8 +210,8 @@ def getCommandArgs(args):
     options = parser.parse_args(args)
 
     # Check if more than one of the following arguments has been specified
-    if options.html + options.rtf + options.json + options.raw > 1:
-       raise IncompatibleOptionsError('Only one of these options may be selected at a time: --html, --json, --raw, --rtf')
+    if options.html + options.rtf + options.json + options.raw + options.attachmentsOnly > 1:
+       raise IncompatibleOptionsError('Only one of these options may be selected at a time: --html, --json, --raw, --rtf, --attachments-only')
 
     if options.dev or options.file_logging:
         options.verbose = True


### PR DESCRIPTION
**v0.30.4**
* [[TeamMsgExtractor #233](https://github.com/TeamMsgExtractor/msg-extractor/issues/233)] Added option to `Message.save` to only save the attachments (`attachmentsOnly`). This can also be used from the command line with the option `--attachments-only`.
* Corrected error string for incompatible options in `Message.save`.
* Fixed if blocks being nested weirdly in `Message.save` instead of being chained with `elif`. Probably an artifact left from adding support for HTML and RTF.