### PR TITLE
Version 0.30.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v0.30.5**
+* [[TeamMsgExtractor #225](https://github.com/TeamMsgExtractor/msg-extractor/issues/225)] Added the ability to generate the HTML body from the RTF body if it is encapsulated HTML. If there is no RTF body, then it will do a very basic generation from the plain text body. This process is automatically performed if the HTML body is missing.
+* Added the ability for the plain text body to sometimes generate from the RTF body if the plain text body does not exist.
+* Added documentation to `Message.save` for the `attachmentsOnly` option.
+
 **v0.30.4**
 * [[TeamMsgExtractor #233](https://github.com/TeamMsgExtractor/msg-extractor/issues/233)] Added option to `Message.save` to only save the attachments (`attachmentsOnly`). This can also be used from the command line with the option `--attachments-only`.
 * Corrected error string for incompatible options in `Message.save`.

--- a/README.rst
+++ b/README.rst
@@ -206,8 +206,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.4-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.4/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.5-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.5/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-01-28'
-__version__ = '0.30.4'
+__date__ = '2022-01-29'
+__version__ = '0.30.5'
 
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tzlocal>=2.1
 compressed_rtf>=1.0.6
 ebcdic>=1.1.1
 beautifulsoup4>=4.10.0
+RTFDE>=0.0.2


### PR DESCRIPTION
**v0.30.5**
* [[TeamMsgExtractor #225](https://github.com/TeamMsgExtractor/msg-extractor/issues/225)] Added the ability to generate the HTML body from the RTF body if it is encapsulated HTML. If there is no RTF body, then it will do a very basic generation from the plain text body. This process is automatically performed if the HTML body is missing.
* Added the ability for the plain text body to sometimes generate from the RTF body if the plain text body does not exist.
* Added documentation to `Message.save` for the `attachmentsOnly` option.