### PR TITLE
v0.30.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v0.30.6**
+* Small adjustments to internal code to make it a bit better.
+* Added `Message.getSaveBody`, `Message.getSaveHtmlBody`, and `Message.getSaveRtfBody`. These three functions generate their respective bodies that will be used when saving the file, allowing you to retrieve the final products without having to write them to the disk first. All arguments that are passed to `Message.save` that would influence the respective bodies are passed to their respective functions.
+* I thought I added the documentation for `attachmentsOnly` to `Message.save` but apparently it was missing. Not sure what happened there but I made sure it was added this time.
+* Added new option to `Message.save` called `charset`. This is used in the preparation of the HTML body when using `preparedHtml`. This is also usable with `--charset CHARSET` from the command line.
+
 **v0.30.5**
 * [[TeamMsgExtractor #225](https://github.com/TeamMsgExtractor/msg-extractor/issues/225)] Added the ability to generate the HTML body from the RTF body if it is encapsulated HTML. If there is no RTF body, then it will do a very basic generation from the plain text body. This process is automatically performed if the HTML body is missing.
 * Added the ability for the plain text body to sometimes generate from the RTF body if the plain text body does not exist.

--- a/README.rst
+++ b/README.rst
@@ -206,8 +206,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.5-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.5/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.6-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.6/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-01-29'
-__version__ = '0.30.5'
+__date__ = '2022-01-30'
+__version__ = '0.30.6'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -51,6 +51,7 @@ def main() -> None:
         kwargs = {
             'allowFallback': args.allowFallback,
             'attachmentsOnly': args.attachmentsOnly,
+            'charset': args.charset,
             'contentId': args.cid,
             'customFilename': args.out_name,
             'customPath': out,

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -394,7 +394,7 @@ class MessageBase(MSGFile):
         """
         # If we can't get an HTML body then we have nothing to do.
         if not self.htmlBody:
-            return b''
+            return self.htmlBody
 
         # Create the BeautifulSoup instance to use.
         soup = bs4.BeautifulSoup(self.htmlBody, 'html.parser')
@@ -402,17 +402,17 @@ class MessageBase(MSGFile):
         # Get a list of image tags to see if we can inject into. If the source
         # of an image starts with "cid:" that means it is one of the attachments
         # and is using the content id of that attachment.
-        tags = tuple(tag for tag in soup.findAll('img') if tag.get('src') and tag.get('src').startswith('cid:'))
+        tags = (tag for tag in soup.findAll('img') if tag.get('src') and tag.get('src').startswith('cid:'))
 
         for tag in tags:
-            # Iterate through the attachments until we get the right
+            # Iterate through the attachments until we get the right one.
             cid = tag['src'][4:]
             data = next((attachment.data for attachment in self.attachments if attachment.cid == cid), None)
             # If we found anything, inject it.
             if data:
                 tag['src'] = (b'data:image;base64,' + base64.b64encode(data)).decode('utf-8')
 
-        return soup.prettify().encode('utf8')
+        return soup.prettify('utf-8')
 
     @property
     def inReplyTo(self) -> str:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -185,6 +185,9 @@ def getCommandArgs(args):
     # --prepared-html
     parser.add_argument('--prepared-html', dest='preparedHtml', action='store_true',
                         help='When used in conjunction with --html, sets whether the HTML output should be prepared for embedded attachments.')
+    # --charset
+    parser.add_argument('--charset', dest='charset', default='utf-8',
+                        help='Character set to use for the prepared HTML in the added tag. (Default: utf-8)')
     # --raw
     parser.add_argument('--raw', dest='raw', action='store_true',
                         help='Sets whether the output should be HTML. If this is not possible, will error.')


### PR DESCRIPTION
**v0.30.6**
* Small adjustments to internal code to make it a bit better.
* Added `Message.getSaveBody`, `Message.getSaveHtmlBody`, and `Message.getSaveRtfBody`. These three functions generate their respective bodies that will be used when saving the file, allowing you to retrieve the final products without having to write them to the disk first. All arguments that are passed to `Message.save` that would influence the respective bodies are passed to their respective functions.
* I thought I added the documentation for `attachmentsOnly` to `Message.save` but apparently it was missing. Not sure what happened there but I made sure it was added this time.
* Added new option to `Message.save` called `charset`. This is used in the preparation of the HTML body when using `preparedHtml`. This is also usable with `--charset CHARSET` from the command line.