### PR TITLE
v0.30.7 (ignore the name of the commit before, that was a typo lol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v0.30.7**
+* [[TeamMsgExtractor #239](https://github.com/TeamMsgExtractor/msg-extractor/issues/239)] Fixed msg.py not having `import pathlib`.
+* After going through the details of the example MSG files provided with the module, specifically unicode.msg, I now am glad I decided to put in some fail-safes in the HTML body processing. One of them does not have an `<html>`, `<head>`, nor `<body>` tag, and so would have had an error. This will actually prevent the header from injecting properly as well, so a bit of validation before was made necessary to ensure the HTML saving would still work.
+* Added new exception `BadHtmlError`.
+* Added new function `utils.validateHtml`.
+* Updated README credits.
+* Changed header logic to generate manually if the header data has been stripped (filled with null bytes) and not just if the stream does not exist.
+
 **v0.30.6**
 * Small adjustments to internal code to make it a bit better.
 * Added `Message.getSaveBody`, `Message.getSaveHtmlBody`, and `Message.getSaveRtfBody`. These three functions generate their respective bodies that will be used when saving the file, allowing you to retrieve the final products without having to write them to the disk first. All arguments that are passed to `Message.save` that would influence the respective bodies are passed to their respective functions.

--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,8 @@ Credits
 
 `Dean Malmgren`_ - First implementation of the setup.py script
 
+`Seamus Tuohy`_ - Developer of the Python RTFDE module. Gave first examples of how to use the module.
+
 `Liam`_ - Significant reorganization and transfer of data.
 
 And thank you to everyone who has opened an issue and helped us track down those pesky bugs.
@@ -206,8 +208,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.6-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.6/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.7-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.7/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/
@@ -218,4 +220,5 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. _Dean Malmgren: https://github.com/deanmalmgren
 .. _Joel Kaufman: https://github.com/joelkaufman
 .. _Liam: https://github.com/LiamPM5
+.. _Seamus Tuohy: https://github.com/seamustuohy
 .. _Discord: https://discord.com/invite/B77McRmzdc

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-01-30'
-__version__ = '0.30.6'
+__date__ = '2022-01-31'
+__version__ = '0.30.7'
 
 import logging
 

--- a/extract_msg/exceptions.py
+++ b/extract_msg/exceptions.py
@@ -12,6 +12,12 @@ This module contains the set of extract_msg exceptions.
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+class BadHtmlError(ValueError):
+    """
+    HTML failed to pass validation.
+    """
+    pass
+
 class ConversionError(Exception):
     """
     An error occured during type conversion.

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -310,6 +310,9 @@ class Message(MessageBase):
             `None` or an empty string to not insert the tag (Default: 'utf-8').
         :param **kwargs: Used to allow kwargs expansion in the save function.
             Arguments absorbed by this are simply ignored.
+
+        :raises BadHtmlError: if :param preparedHtml: is False and the HTML
+            fails to validate.
         """
         if self.htmlBody:
             # Inject the header into the data.
@@ -328,15 +331,15 @@ class Message(MessageBase):
                     tag = bs4.Tag(parser = bs, name = 'meta', attrs = tagAttrs, can_be_empty_element = True)
                     # Add the tag to the head section.
                     if bs.find('head'):
-                        bs.find('head').insert(1, tag)
+                        bs.find('head').insert(0, tag)
                     else:
                         # If we are here, the head doesn't exist, so let's add
                         # it.
                         if bs.find('html'):
                             # This should always be true, but I want to be safe.
                             head = bs4.Tag(parser = bs, name = 'head')
-                            head.insert(1, tag)
-                            bs.find('html').insert(1, head)
+                            head.insert(0, tag)
+                            bs.find('html').insert(0, head)
 
                     data = bs.prettify('utf-8')
 

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -327,7 +327,7 @@ class MessageBase(MSGFile):
             return self._header
         except AttributeError:
             headerText = self._getStringStream('__substg1.0_007D')
-            if headerText is not None:
+            if headerText:
                 self._header = EmailParser().parsestr(headerText)
                 self._header['date'] = self.date
             else:

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -2,6 +2,7 @@ import codecs
 import copy
 import logging
 import os
+import pathlib
 import zipfile
 
 import olefile


### PR DESCRIPTION
**v0.30.7**
* [[TeamMsgExtractor #239](https://github.com/TeamMsgExtractor/msg-extractor/issues/239)] Fixed msg.py not having `import pathlib`.
* After going through the details of the example MSG files provided with the module, specifically unicode.msg, I now am glad I decided to put in some fail-safes in the HTML body processing. One of them does not have an `<html>`, `<head>`, nor `<body>` tag, and so would have had an error. This will actually prevent the header from injecting properly as well, so a bit of validation before was made necessary to ensure the HTML saving would still work.
* Added new exception `BadHtmlError`.
* Added new function `utils.validateHtml`.
* Updated README credits.
* Changed header logic to generate manually if the header data has been stripped (filled with null bytes) and not just if the stream does not exist.