### PR TITLE
v0.30.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.30.8**
+* Update `imapclient` requirement to `>=2.1.0` instead of `==2.1.0`. Currently there are no changes that would prevent current future versions from working.
+
 **v0.30.7**
 * [[TeamMsgExtractor #239](https://github.com/TeamMsgExtractor/msg-extractor/issues/239)] Fixed msg.py not having `import pathlib`.
 * After going through the details of the example MSG files provided with the module, specifically unicode.msg, I now am glad I decided to put in some fail-safes in the HTML body processing. One of them does not have an `<html>`, `<head>`, nor `<body>` tag, and so would have had an error. This will actually prevent the header from injecting properly as well, so a bit of validation before was made necessary to ensure the HTML saving would still work.

--- a/README.rst
+++ b/README.rst
@@ -208,8 +208,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.7-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.7/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.8-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.8/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/mattgwwalker/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2022-01-31'
-__version__ = '0.30.7'
+__version__ = '0.30.8'
 
 import logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 # First level requirements
-imapclient==2.1.0
+imapclient>=2.1.0
 olefile>=0.46
 tzlocal>=2.1
 compressed_rtf>=1.0.6


### PR DESCRIPTION
**v0.30.8**
* Update `imapclient` requirement to `>=2.1.0` instead of `==2.1.0`. Currently there are no changes that would prevent current future versions from working.