### PR TITLE
v0.30.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.30.10**
+* [[TeamMsgExtractor #249](https://github.com/TeamMsgExtractor/msg-extractor/issues/249)] Fixed exception catching not properly accessing the exception (forgot to go through one of the submodules to access exception).
+* Updated docstring for `MessageBase.deencapsulatedRtf`.
+
 **v0.30.9**
 * Fixed the behavior of `Properties.get` so it actually behaves like a dict (that was the intent of it, but I did it the wrong way for some reason).
 * Fixed a type that caused an exception when no HTML body could be found nor generated.

--- a/README.rst
+++ b/README.rst
@@ -208,8 +208,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.9-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.9/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.10-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.10/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/mattgwwalker/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-03-29'
-__version__ = '0.30.9'
+__date__ = '2022-04-09'
+__version__ = '0.30.10'
 
 import logging
 

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -281,7 +281,8 @@ class MessageBase(MSGFile):
     @property
     def deencapsulatedRtf(self) -> RTFDE.DeEncapsulator:
         """
-        Returns the instance of the deencapsulated RTF body.
+        Returns the instance of the deencapsulated RTF body. If there is no RTF
+        body or the body is not encasulated, returns None.
         """
         try:
             return self._deencapsultor
@@ -291,10 +292,10 @@ class MessageBase(MSGFile):
                 try:
                     self._deencapsultor = RTFDE.DeEncapsulator(self.rtfBody)
                     self._deencapsultor.deencapsulate()
-                except RTFDE.NotEncapsulatedRtf as e:
+                except RTFDE.exceptions.NotEncapsulatedRtf as e:
                     logger.debug("RTF body is not encapsulated.")
                     self._deencapsultor = None
-                except RTFDE.MalformedEncapsulatedRtf as _e:
+                except RTFDE.exceptions.MalformedEncapsulatedRtf as _e:
                     logger.info("RTF body contains malformed encapsulated content.")
                     self._deencapsultor = None
             else:


### PR DESCRIPTION
**v0.30.10**
* [[TeamMsgExtractor #249](https://github.com/TeamMsgExtractor/msg-extractor/issues/249)] Fixed exception catching not properly accessing the exception (forgot to go through one of the submodules to access exception).
* Updated docstring for `MessageBase.deencapsulatedRtf`.