### PR TITLE
Version 0.30.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.30.13**
+* [[TeamMsgExtractor #257](https://github.com/TeamMsgExtractor/msg-extractor/issues/257)] Fixed missing documentation for `customPath` keyword argument to `Attachment.save`.
+
 **v0.30.12**
 * [[TeamMsgExtractor #253](https://github.com/TeamMsgExtractor/msg-extractor/issues/253)] Fixed various docstring issues.
 

--- a/README.rst
+++ b/README.rst
@@ -206,8 +206,8 @@ And thank you to everyone who has opened an issue and helped us track down those
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.12-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.30.12/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.30.13-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.30.13/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-05-01'
-__version__ = '0.30.12'
+__date__ = '2022-05-26'
+__version__ = '0.30.13'
 
 import logging
 

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -111,6 +111,10 @@ class Attachment(AttachmentBase):
         After the name to use has been determined, it will then be shortened to
         make sure that it is not more than the value of :param maxNameLength:.
 
+        To change the directory that the attachment is saved to, set the value
+        of :param customPath: when calling this function. The default save
+        directory is the working directory.
+
         If you want to save the contents into a ZipFile or similar object,
         either pass a path to where you want to create one or pass an instance
         to :param zip:. If :param zip: is an instance, :param customPath: will


### PR DESCRIPTION
**v0.30.13**
* [[TeamMsgExtractor #257](https://github.com/TeamMsgExtractor/msg-extractor/issues/257)] Fixed missing documentation for `customPath` keyword argument to `Attachment.save`.