### PR TITLE
Version 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
+**v0.34.0**
+* [[TeamMsgExtractor #102](https://github.com/TeamMsgExtractor/msg-extractor/issues/102)] Added the option to directly save body to pdf. This requires that you either have wkhtmltopdf on your path or that you provide a path directly to it in order to work. Simply pass `pdf = True` to save to turn it on. More details in the doc for the save function. You can also do this from the command line using the `--pdf` option, incompatible with other body types.
+* Added `--glob` option for allowing you to provide an msg path that will evaluate wildcards.
+* Removed per-file output names as they weren't actually functional and currently add too much complexity. If anyone knows a way to handle it directly with `argparse` let me know.
+* Added `chardet` as a requirement to help work around an error in `RTFDE`.
+
 **v0.33.0**
 * [[TeamMsgExtractor #212](https://github.com/TeamMsgExtractor/msg-extractor/issues/212)] Added support for Task objects.
-* Added additional parameter `overrideClass` to all `_ensureSetX` type functions. This parameter is a class to initialize using the data, if provided. The data will be provided as the first argument to the `__init__` function of the class *if* the data is not `None`. If the data is done, the value set and returned from `_ensureSetX` will be `None`. This can be overriden using the second added parameter, which defaults to this behavior. Simply set `preserveNone` to `False` to force the data to be passed to the class. Keep in mind that this means the class will receive `None` as it's first parameter.
+* Added additional parameter `overrideClass` to all `_ensureSetX` type functions. This parameter is a class to initialize using the data, if provided. The data will be provided as the first argument to the `__init__` function of the class *if* the data is not `None`. If the data is done, the value set and returned from `_ensureSetX` will be `None`. This can be overridden using the second added parameter, which defaults to this behavior. Simply set `preserveNone` to `False` to force the data to be passed to the class. Keep in mind that this means the class will receive `None` as it's first parameter.
 * Updated `Named` class to make it more like the dictionary it is build on top of. Specifically, added `keys`, `values`, and `items` as functions.
 * Fixed issue in `Named` where old code wasn't deleted, causing some named properties to be completely omitted.
 * Improved efficiency of `Named` by making it so `get` no longer copied the entire dictionary repeatedly while looking for the property.
 * Fixed typo in `Attachment` that caused embedded msg files to still regenerate the `Named` instance even though they should have been using the parent's.
 * Updated fields in `MSGFile` to use enums.
-* Added additional properties to `MSGFile`. 
-* Significant cleanup. 
+* Added additional properties to `MSGFile`.
+* Significant cleanup.
 
 **v0.32.0**
 * [[TeamMsgExtractor #217](https://github.com/TeamMsgExtractor/msg-extractor/issues/217)] Redesigned named properties to be much more efficient. All in all, load times for MSG files are significantly improved all around.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added `--glob` option for allowing you to provide an msg path that will evaluate wildcards.
 * Removed per-file output names as they weren't actually functional and currently add too much complexity. If anyone knows a way to handle it directly with `argparse` let me know.
 * Added `chardet` as a requirement to help work around an error in `RTFDE`.
+* Looking into some of the unsupported encodings revealed at least one to be supported, but was missed due to the name not being registered as an alias.
 
 **v0.33.0**
 * [[TeamMsgExtractor #212](https://github.com/TeamMsgExtractor/msg-extractor/issues/212)] Added support for Task objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Removed per-file output names as they weren't actually functional and currently add too much complexity. If anyone knows a way to handle it directly with `argparse` let me know.
 * Added `chardet` as a requirement to help work around an error in `RTFDE`.
 * Looking into some of the unsupported encodings revealed at least one to be supported, but was missed due to the name not being registered as an alias.
+* Fixed a bug that prevented an HTML body from the plain text body when it couldn't be generated any other way. This happened when the RTF body existed and the plain text body existed, but the RTF body was not encapsulated HTML.
+* Due to several of the issues with RTFDE preventing saving due to exceptions, the option `ignoreRtfDeErrors` has been added to the `MessageBase` class and `openMsg`. It can also be enabled from the command line with `--ignore-rtfde`. This option will make it so all exceptions will be silenced from the module.
 
 **v0.33.0**
 * [[TeamMsgExtractor #212](https://github.com/TeamMsgExtractor/msg-extractor/issues/212)] Added support for Task objects.

--- a/README.rst
+++ b/README.rst
@@ -221,8 +221,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.33.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.33.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.34.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.34.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/README.rst
+++ b/README.rst
@@ -52,49 +52,47 @@ Currently, the README is in the process of being redone. For now, please
 refer to the usage information provided from the program's help dialog:
 ::
 
-    usage: extract_msg [-h] [--use-content-id] [--dev] [--validate] [--json]
-                       [--file-logging] [--verbose] [--log LOG]
-                       [--config CONFIG_PATH] [--out OUT_PATH] [--use-filename]
-                       [--dump-stdout] [--html] [--raw] [--rtf]
-                       [--allow-fallback] [--out-name OUT_NAME] msg [msg ...]
+    usage: extract_msg [-h] [--use-content-id] [--dev] [--validate] [--json] [--file-logging] [--verbose] [--log LOG] [--config CONFIGPATH] [--out OUTPATH] [--use-filename]
+                   [--dump-stdout] [--html] [--pdf] [--wk-path WKPATH] [--wk-options [WKOPTIONS ...]] [--prepared-html] [--charset CHARSET] [--raw] [--rtf]
+                   [--allow-fallback] [--zip ZIP] [--attachments-only] [--out-name OUTNAME | --glob] [--ignore-rtfde] [--progress]
+                   msg [msg ...]
 
-    extract_msg: Extracts emails and attachments saved in Microsoft Outlook's
-    .msg files. https://github.com/TeamMsgExtractor/msg-extractor
+    extract_msg: Extracts emails and attachments saved in Microsoft Outlook's .msg files. https://github.com/TeamMsgExtractor/msg-extractor
 
     positional arguments:
-        msg                   An msg file to be parsed
+    msg                   An MSG file to be parsed.
 
     optional arguments:
-        -h, --help            show this help message and exit
-        --use-content-id, --cid
-                              Save attachments by their Content ID, if they have
-                              one. Useful when working with the HTML body.
-        --dev                 Changes to use developer mode. Automatically
-                              enables the --verbose flag. Takes precedence over
-                              the --validate flag.
-        --validate            Turns on file validation mode. Turns off regular
-                              file output.
-        --json                Changes to write output files as json.
-        --file-logging        Enables file logging. Implies --verbose.
-        --verbose             Turns on console logging.
-        --log LOG             Set the path to write the file log to.
-        --config CONFIG_PATH  Set the path to load the logging config from.
-        --out OUT_PATH        Set the folder to use for the program output.
-                              (Default: Current directory)
-        --use-filename        Sets whether the name of each output is based on
-                              the msg filename.
-        --dump-stdout         Tells the program to dump the message body (plain
-                              text) to stdout. Overrides saving arguments.
-        --html                Sets whether the output should be html. If this is
-                              not possible, will error.
-        --raw                 Sets whether the output should be raw. If this is
-                              not possible, will error.
-        --rtf                 Sets whether the output should be rtf. If this is
-                              not possible, will error.
-        --allow-fallback      Tells the program to fallback to a different save
-                              type if the selected one is not possible.
-        --out-name OUT_NAME   Name to be used with saving the file output.
-                              Should come immediately after the file name.
+    -h, --help            show this help message and exit
+    --use-content-id, --cid
+                          Save attachments by their Content ID, if they have one. Useful when working with the HTML body.
+    --dev                 Changes to use developer mode. Automatically enables the --verbose flag. Takes precedence over the --validate flag.
+    --validate            Turns on file validation mode. Turns off regular file output.
+    --json                Changes to write output files as json.
+    --file-logging        Enables file logging. Implies --verbose.
+    --verbose             Turns on console logging.
+    --log LOG             Set the path to write the file log to.
+    --config CONFIGPATH   Set the path to load the logging config from.
+    --out OUTPATH         Set the folder to use for the program output. (Default: Current directory)
+    --use-filename        Sets whether the name of each output is based on the msg filename.
+    --dump-stdout         Tells the program to dump the message body (plain text) to stdout. Overrides saving arguments.
+    --html                Sets whether the output should be HTML. If this is not possible, will error.
+    --pdf                 Saves the body as a PDF. If this is not possible, will error.
+    --wk-path WKPATH      Overrides the path for finding wkhtmltopdf.
+    --wk-options [WKOPTIONS ...]
+                        Sets additional options to be used in wkhtmltopdf. Should be a series of options and values, replacing the - or -- in the beginning with + or ++,
+                        respectively. For example: --wk-options "+O Landscape"
+    --prepared-html       When used in conjunction with --html, sets whether the HTML output should be prepared for embedded attachments.
+    --charset CHARSET     Character set to use for the prepared HTML in the added tag. (Default: utf-8)
+    --raw                 Sets whether the output should be raw. If this is not possible, will error.
+    --rtf                 Sets whether the output should be RTF. If this is not possible, will error.
+    --allow-fallback      Tells the program to fallback to a different save type if the selected one is not possible.
+    --zip ZIP             Path to use for saving to a zip file.
+    --attachments-only    Specify to only save attachments from an msg file.
+    --out-name OUTNAME    Name to be used with saving the file output. Cannot be used if you are saving more than one file.
+    --glob, --wildcard    Interpret all paths as having wildcards. Incompatible with --out-name.
+    --ignore-rtfde        Ignores all errors thrown from RTFDE when trying to save. Useful for allowing fallback to continue when an exception happens.
+--progress            Shows what file the program is currently working on during it's progress.
 
 **To use this in your own script**, start by using:
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -9,7 +9,7 @@ extract_msg:
 https://github.com/TeamMsgExtractor/msg-extractor
 """
 
-# --- LICENSE.txt -----------------------------------------------------------------
+# --- LICENSE.txt --------------------------------------------------------------
 #
 #    Copyright 2013-2022 Matthew Walker and Destiny Peterson
 #

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-06-08'
-__version__ = '0.33.0'
+__date__ = '2022-06-11'
+__version__ = '0.34.0'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -15,14 +15,14 @@ def main() -> None:
     # Determine where to save the files to.
     currentDir = os.getcwd() # Store this in case the path changes.
     if not args.zip:
-        if args.out_path:
-            if not os.path.exists(args.out_path):
-                os.makedirs(args.out_path)
-            out = args.out_path
+        if args.outPath:
+            if not os.path.exists(args.outPath):
+                os.makedirs(args.outPath)
+            out = args.outPath
         else:
             out = currentDir
     else:
-        out = args.out_path if args.out_path else ''
+        out = args.outPath if args.outPath else ''
 
     if args.dev:
         import extract_msg.dev
@@ -34,7 +34,7 @@ def main() -> None:
 
         from extract_msg import validation
 
-        valResults = {x[0]: validation.validate(x[0]) for x in args.msgs}
+        valResults = {x: validation.validate(x) for x in args.msgs}
         filename = f'validation {int(time.time())}.json'
         print('Validation Results:')
         pprint.pprint(valResults)
@@ -43,8 +43,8 @@ def main() -> None:
             json.dump(valResults, fil)
         input('Press enter to exit...')
     else:
-        if not args.dump_stdout:
-            utils.setupLogging(args.config_path, level, args.log, args.file_logging)
+        if not args.dumpStdout:
+            utils.setupLogging(args.configPath, level, args.log, args.fileLogging)
 
         # Quickly make a dictionary for the keyword arguments.
         kwargs = {
@@ -52,25 +52,30 @@ def main() -> None:
             'attachmentsOnly': args.attachmentsOnly,
             'charset': args.charset,
             'contentId': args.cid,
-            'customFilename': args.out_name,
+            'customFilename': args.outName,
             'customPath': out,
             'html': args.html,
             'json': args.json,
+            'pdf': args.pdf,
             'preparedHtml': args.preparedHtml,
             'rtf': args.rtf,
-            'useMsgFilename': args.use_filename,
+            'useMsgFilename': args.useFilename,
+            'wkOptions': args.wkOptions,
+            'wkPath': args.wkPath,
             'zip': args.zip,
         }
 
         for x in args.msgs:
             try:
-                with utils.openMsg(x[0]) as msg:
-                    if args.dump_stdout:
+                if args.progress:
+                    print(f'Saving file "{x}"...')
+                with utils.openMsg(x) as msg:
+                    if args.dumpStdout:
                         print(msg.body)
                     else:
                         msg.save(**kwargs)
             except Exception as e:
-                print(f'Error with file "{x[0]}": {traceback.format_exc()}')
+                print(f'Error with file "{x}": {traceback.format_exc()}')
 
 
 if __name__ == '__main__':

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -55,6 +55,7 @@ def main() -> None:
             'customFilename': args.outName,
             'customPath': out,
             'html': args.html,
+            'ignoreRtfDeErrors': args.ignoreRtfDeErrors,
             'json': args.json,
             'pdf': args.pdf,
             'preparedHtml': args.preparedHtml,

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -55,7 +55,6 @@ def main() -> None:
             'customFilename': args.outName,
             'customPath': out,
             'html': args.html,
-            'ignoreRtfDeErrors': args.ignoreRtfDeErrors,
             'json': args.json,
             'pdf': args.pdf,
             'preparedHtml': args.preparedHtml,
@@ -66,11 +65,15 @@ def main() -> None:
             'zip': args.zip,
         }
 
+        openKwargs = {
+            'ignoreRtfDeErrors': args.ignoreRtfDeErrors,
+        }
+
         for x in args.msgs:
             try:
                 if args.progress:
                     print(f'Saving file "{x}"...')
-                with utils.openMsg(x) as msg:
+                with utils.openMsg(x, **openKwargs) as msg:
                     if args.dumpStdout:
                         print(msg.body)
                     else:

--- a/extract_msg/exceptions.py
+++ b/extract_msg/exceptions.py
@@ -12,6 +12,7 @@ This module contains the set of extract_msg exceptions.
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+
 class BadHtmlError(ValueError):
     """
     HTML failed to pass validation.
@@ -27,6 +28,12 @@ class ConversionError(Exception):
 class DataNotFoundError(Exception):
     """
     Requested stream type was unavailable.
+    """
+    pass
+
+class ExecutableNotFound(Exception):
+    """
+    Could not find the specified executable.
     """
     pass
 
@@ -75,5 +82,11 @@ class UnrecognizedMSGTypeError(TypeError):
     """
     An exception that is raised when the module cannot determine how to properly
     open a specific class of msg file.
+    """
+    pass
+
+class WKError(RuntimeError):
+    """
+    An error occured while running wkhtmltopdf.
     """
     pass

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import pathlib
+import subprocess
 import zipfile
 
 import bs4
@@ -9,9 +10,9 @@ import bs4
 from imapclient.imapclient import decode_utf7
 
 from . import constants
-from .exceptions import DataNotFoundError, IncompatibleOptionsError
+from .exceptions import DataNotFoundError, IncompatibleOptionsError, WKError
 from .message_base import MessageBase
-from .utils import addNumToDir, addNumToZipDir, createZipOpen, injectHtmlHeader, injectRtfHeader, inputToBytes, inputToString, prepareFilename
+from .utils import addNumToDir, addNumToZipDir, createZipOpen, findWk, injectHtmlHeader, injectRtfHeader, inputToBytes, inputToString, prepareFilename
 
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,14 @@ class Message(MessageBase):
             usage, doing things like adding tags, injecting attachments, etc.
             This is useful for things like trying to convert the HTML body
             directly to PDF.
+        :param pdf: Used to enable saving the body as a PDF file.
+        :param wkPath: Used to manually specify the path of the wkhtmltopdf
+            executable. If not specified, the function will try to find it.
+            Useful if wkhtmltopdf is not on the path. If :param pdf: is False,
+            this argument is ignored.
+        :param wkOptions: Used to specify additional options to wkhtmltopdf.
+            this must be a list or list-like object composed of strings and
+            bytes.
         """
         # Move keyword arguments into variables.
         _json = kwargs.get('json', False)
@@ -129,6 +138,11 @@ class Message(MessageBase):
         attachOnly = kwargs.get('attachmentsOnly', False)
         # Track if we are skipping attachments.
         skipAttachments = kwargs.get('skipAttachments', False)
+
+        # If we are doing PDF, we immediately need to try to find wkhtmltopdf.
+        if pdf:
+            wkPath = findWk(kwargs.get('wkPath'))
+            kwargs['preparedHtml'] = True
 
         # ZipFile handling.
         if _zip:
@@ -252,21 +266,55 @@ class Message(MessageBase):
 
             if not attachOnly:
                 # Determine the extension to use for the body.
-                fext = 'json' if _json else fext
-
-                with _open(str(path / ('message.' + fext)), mode) as f:
-                    if _json:
-                        emailObj = json.loads(self.getJson())
-                        if not skipAttachments:
-                            emailObj['attachments'] = attachmentNames
-
-                        f.write(inputToBytes(json.dumps(emailObj), 'utf-8'))
-                    elif useHtml:
-                        f.write(self.getSaveHtmlBody(**kwargs))
-                    elif useRtf:
-                        f.write(self.getSaveRtfBody(**kwargs))
+                if pdf:
+                    # First thing is first, we need to parse our wkOptions if
+                    # they exist.
+                    wkOptions = kwargs.get('wkOptions')
+                    if wkOptions:
+                        try:
+                            # Try to convert to a list, whatever it is, and
+                            # fail if it is not possible.
+                            parsedWkOptions = [*wkOptions]
+                        except TypeError:
+                            raise TypeError(':param wkOptions: must be an iterable, not {type(wkOptions)}.')
                     else:
-                        f.write(self.getSaveBody(**kwargs))
+                        parsedWkOptions = []
+
+                    # Confirm that all of our options we now have are either
+                    # strings or bytes.
+                    if not all(isinstance(option, (str, bytes)) for option in parsedWkOptions):
+                        raise TypeError(':param wkOptions: must be an iterable of strings and bytes.')
+
+                    # We call the program to convert the html, but give tell it
+                    # the data will go in and come out through stdin and stdout,
+                    # respectively. This way we don't have to write temporary
+                    # files to the disk. We also ask that it be quiet about it.
+                    process = subprocess.Popen([wkPath, *parsedWkOptions, '-', '-'], shell = True, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+                    # Give the program the data and wait for the program to
+                    # finish.
+                    output = process.communicate(self.getSaveHtmlBody(**kwargs))
+                    if process.returncode != 0:
+                        raise WKError(output[1].decode('utf-8'))
+
+                    with _open(str(path / 'message.pdf'), mode) as f:
+                        f.write(output[0])
+
+                else:
+                    fext = 'json' if _json else fext
+
+                    with _open(str(path / ('message.' + fext)), mode) as f:
+                        if _json:
+                            emailObj = json.loads(self.getJson())
+                            if not skipAttachments:
+                                emailObj['attachments'] = attachmentNames
+
+                            f.write(inputToBytes(json.dumps(emailObj), 'utf-8'))
+                        elif useHtml:
+                            f.write(self.getSaveHtmlBody(**kwargs))
+                        elif useRtf:
+                            f.write(self.getSaveRtfBody(**kwargs))
+                        else:
+                            f.write(self.getSaveBody(**kwargs))
 
         except Exception:
             if not _zip:

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -115,6 +115,7 @@ class Message(MessageBase):
         html = kwargs.get('html', False)
         rtf = kwargs.get('rtf', False)
         raw = kwargs.get('raw', False)
+        pdf = kwargs.get('pdf', False)
         allowFallback = kwargs.get('allowFallback', False)
         _zip = kwargs.get('zip')
         maxNameLength = kwargs.get('maxNameLength', 256)
@@ -157,8 +158,8 @@ class Message(MessageBase):
         kwargs['customFilename'] = None
 
         # Check if incompatible options have been provided in any way.
-        if _json + html + rtf + raw + attachOnly > 1:
-            raise IncompatibleOptionsError('Only one of the following options may be used at a time: json, raw, html, rtf, attachmentsOnly.')
+        if _json + html + rtf + raw + attachOnly + pdf > 1:
+            raise IncompatibleOptionsError('Only one of the following options may be used at a time: json, raw, html, rtf, attachmentsOnly, pdf.')
 
         # TODO: insert code here that will handle checking all of the msg files to see if the path with overflow.
 

--- a/extract_msg/message.py
+++ b/extract_msg/message.py
@@ -139,9 +139,7 @@ class Message(MessageBase):
         # Track if we are skipping attachments.
         skipAttachments = kwargs.get('skipAttachments', False)
 
-        # If we are doing PDF, we immediately need to try to find wkhtmltopdf.
         if pdf:
-            wkPath = findWk(kwargs.get('wkPath'))
             kwargs['preparedHtml'] = True
 
         # ZipFile handling.
@@ -241,80 +239,53 @@ class Message(MessageBase):
 
         try:
             if not attachOnly:
-                # Check whether we should be using HTML or RTF.
-                fext = 'txt'
+                # Check what to save the body with.
+                fext = 'json' if _json else 'txt'
 
                 useHtml = False
+                usePdf = False
                 useRtf = False
                 if html:
                     if self.htmlBody:
                         useHtml = True
                         fext = 'html'
                     elif not allowFallback:
-                        raise DataNotFoundError('Could not find the htmlBody')
+                        raise DataNotFoundError('Could not find the htmlBody.')
 
-                if rtf or (html and not useHtml):
+                if pdf:
+                    if self.htmlBody:
+                        usePdf = True
+                        fext = 'pdf'
+                    elif not allowFallback:
+                        raise DataNotFoundError('Count not find the htmlBody to convert to pdf.')
+
+                if rtf or (html and not useHtml) or (pdf and not usePdf):
                     if self.rtfBody:
                         useRtf = True
                         fext = 'rtf'
                     elif not allowFallback:
-                        raise DataNotFoundError('Could not find the rtfBody')
+                        raise DataNotFoundError('Could not find the rtfBody.')
 
             if not skipAttachments:
                 # Save the attachments.
                 attachmentNames = [attachment.save(**kwargs) for attachment in self.attachments]
 
             if not attachOnly:
-                # Determine the extension to use for the body.
-                if pdf:
-                    # First thing is first, we need to parse our wkOptions if
-                    # they exist.
-                    wkOptions = kwargs.get('wkOptions')
-                    if wkOptions:
-                        try:
-                            # Try to convert to a list, whatever it is, and
-                            # fail if it is not possible.
-                            parsedWkOptions = [*wkOptions]
-                        except TypeError:
-                            raise TypeError(':param wkOptions: must be an iterable, not {type(wkOptions)}.')
+                with _open(str(path / ('message.' + fext)), mode) as f:
+                    if _json:
+                        emailObj = json.loads(self.getJson())
+                        if not skipAttachments:
+                            emailObj['attachments'] = attachmentNames
+
+                        f.write(inputToBytes(json.dumps(emailObj), 'utf-8'))
+                    elif useHtml:
+                        f.write(self.getSaveHtmlBody(**kwargs))
+                    elif usePdf:
+                        f.write(self.getSavePdfBody(**kwargs))
+                    elif useRtf:
+                        f.write(self.getSaveRtfBody(**kwargs))
                     else:
-                        parsedWkOptions = []
-
-                    # Confirm that all of our options we now have are either
-                    # strings or bytes.
-                    if not all(isinstance(option, (str, bytes)) for option in parsedWkOptions):
-                        raise TypeError(':param wkOptions: must be an iterable of strings and bytes.')
-
-                    # We call the program to convert the html, but give tell it
-                    # the data will go in and come out through stdin and stdout,
-                    # respectively. This way we don't have to write temporary
-                    # files to the disk. We also ask that it be quiet about it.
-                    process = subprocess.Popen([wkPath, *parsedWkOptions, '-', '-'], shell = True, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
-                    # Give the program the data and wait for the program to
-                    # finish.
-                    output = process.communicate(self.getSaveHtmlBody(**kwargs))
-                    if process.returncode != 0:
-                        raise WKError(output[1].decode('utf-8'))
-
-                    with _open(str(path / 'message.pdf'), mode) as f:
-                        f.write(output[0])
-
-                else:
-                    fext = 'json' if _json else fext
-
-                    with _open(str(path / ('message.' + fext)), mode) as f:
-                        if _json:
-                            emailObj = json.loads(self.getJson())
-                            if not skipAttachments:
-                                emailObj['attachments'] = attachmentNames
-
-                            f.write(inputToBytes(json.dumps(emailObj), 'utf-8'))
-                        elif useHtml:
-                            f.write(self.getSaveHtmlBody(**kwargs))
-                        elif useRtf:
-                            f.write(self.getSaveRtfBody(**kwargs))
-                        else:
-                            f.write(self.getSaveBody(**kwargs))
+                        f.write(self.getSaveBody(**kwargs))
 
         except Exception:
             if not _zip:
@@ -400,6 +371,58 @@ class Message(MessageBase):
             return data
         else:
             return self.htmlBody
+
+    def getSavePdfBody(self, **kwargs) -> bytes:
+        """
+        Returns the PDF body that will be used in saving based on the arguments.
+
+        :param wkPath: Used to manually specify the path of the wkhtmltopdf
+            executable. If not specified, the function will try to find it.
+            Useful if wkhtmltopdf is not on the path. If :param pdf: is False,
+            this argument is ignored.
+        :param wkOptions: Used to specify additional options to wkhtmltopdf.
+            this must be a list or list-like object composed of strings and
+            bytes.
+        :param kwargs: Used to allow kwargs expansion in the save function.
+            Arguments absorbed by this are simply ignored.
+
+        :raises ExecutableNotFound: The wkhtmltopdf executable could not be
+            found.
+        :raises WKError: Something went wrong in creating the PDF body.
+        """
+        # Immediately try to find the executable.
+        wkPath = findWk(kwargs.get('wkPath'))
+
+        # First thing is first, we need to parse our wkOptions if
+        # they exist.
+        wkOptions = kwargs.get('wkOptions')
+        if wkOptions:
+            try:
+                # Try to convert to a list, whatever it is, and
+                # fail if it is not possible.
+                parsedWkOptions = [*wkOptions]
+            except TypeError:
+                raise TypeError(':param wkOptions: must be an iterable, not {type(wkOptions)}.')
+        else:
+            parsedWkOptions = []
+
+        # Confirm that all of our options we now have are either
+        # strings or bytes.
+        if not all(isinstance(option, (str, bytes)) for option in parsedWkOptions):
+            raise TypeError(':param wkOptions: must be an iterable of strings and bytes.')
+
+        # We call the program to convert the html, but give tell it
+        # the data will go in and come out through stdin and stdout,
+        # respectively. This way we don't have to write temporary
+        # files to the disk. We also ask that it be quiet about it.
+        process = subprocess.Popen([wkPath, *parsedWkOptions, '-', '-'], shell = True, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+        # Give the program the data and wait for the program to
+        # finish.
+        output = process.communicate(self.getSaveHtmlBody(**kwargs))
+        if process.returncode != 0:
+            raise WKError(output[1].decode('utf-8'))
+
+        return output[0]
 
     def getSaveRtfBody(self, **kwargs) -> bytes:
         """

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -252,6 +252,7 @@ class MessageBase(MSGFile):
                     if not self.__ignoreRtfDeErrors:
                         raise
                     logger.exception('Unhandled error happened while using RTFDE. You have choosen to ignore these errors.')
+                    self._deencapsultor = None
             else:
                 self._deencapsultor = None
             return self._deencapsultor

--- a/extract_msg/message_signed.py
+++ b/extract_msg/message_signed.py
@@ -98,23 +98,32 @@ class MessageSigned(MessageSignedBase):
 
         :param attachmentsOnly: Turns off saving the body and only saves the
             attachments when set.
+        :param skipAttachments: Turns off saving attachments.
         :param charset: If the html is being prepared, the charset to use for
             the Content-Type meta tag to insert. This exists to ensure that
             something parsing the html can properly determine the encoding (as
             not having this tag can cause errors in some programs). Set this to
             `None` or an empty string to not insert the tag (Default: 'utf-8').
-        :param kwargs: Used to allow kwags expansion in the save function.
+        :param kwargs: Used to allow kwargs expansion in the save function.
         :param preparedHtml: When set, prepares the HTML body for standalone
             usage, doing things like adding tags, injecting attachments, etc.
             This is useful for things like trying to convert the HTML body
             directly to PDF.
+        :param pdf: Used to enable saving the body as a PDF file.
+        :param wkPath: Used to manually specify the path of the wkhtmltopdf
+            executable. If not specified, the function will try to find it.
+            Useful if wkhtmltopdf is not on the path. If :param pdf: is False,
+            this argument is ignored.
+        :param wkOptions: Used to specify additional options to wkhtmltopdf.
+            this must be a list or list-like object composed of strings and
+            bytes.
         """
-
         # Move keyword arguments into variables.
         _json = kwargs.get('json', False)
         html = kwargs.get('html', False)
         rtf = kwargs.get('rtf', False)
         raw = kwargs.get('raw', False)
+        pdf = kwargs.get('pdf', False)
         allowFallback = kwargs.get('allowFallback', False)
         _zip = kwargs.get('zip')
         maxNameLength = kwargs.get('maxNameLength', 256)
@@ -126,6 +135,11 @@ class MessageSigned(MessageSignedBase):
 
         # Track if we are only saving the attachments.
         attachOnly = kwargs.get('attachmentsOnly', False)
+        # Track if we are skipping attachments.
+        skipAttachments = kwargs.get('skipAttachments', False)
+
+        if pdf:
+            kwargs['preparedHtml'] = True
 
         # ZipFile handling.
         if _zip:
@@ -155,8 +169,8 @@ class MessageSigned(MessageSignedBase):
         kwargs['customFilename'] = None
 
         # Check if incompatible options have been provided in any way.
-        if _json + html + rtf + raw + attachOnly > 1:
-            raise IncompatibleOptionsError('Only one of the following options may be used at a time: json, raw, html, rtf, attachmentsOnly.')
+        if _json + html + rtf + raw + attachOnly + pdf > 1:
+            raise IncompatibleOptionsError('Only one of the following options may be used at a time: json, raw, html, rtf, attachmentsOnly, pdf.')
 
         # TODO: insert code here that will handle checking all of the msg files to see if the path with overflow.
 
@@ -224,40 +238,49 @@ class MessageSigned(MessageSignedBase):
 
         try:
             if not attachOnly:
-                # Check whether we should be using HTML or RTF.
-                fext = 'txt'
+                # Check what to save the body with.
+                fext = 'json' if _json else 'txt'
 
                 useHtml = False
+                usePdf = False
                 useRtf = False
                 if html:
                     if self.htmlBody:
                         useHtml = True
                         fext = 'html'
                     elif not allowFallback:
-                        raise DataNotFoundError('Could not find the htmlBody')
+                        raise DataNotFoundError('Could not find the htmlBody.')
 
-                if rtf or (html and not useHtml):
+                if pdf:
+                    if self.htmlBody:
+                        usePdf = True
+                        fext = 'pdf'
+                    elif not allowFallback:
+                        raise DataNotFoundError('Count not find the htmlBody to convert to pdf.')
+
+                if rtf or (html and not useHtml) or (pdf and not usePdf):
                     if self.rtfBody:
                         useRtf = True
                         fext = 'rtf'
                     elif not allowFallback:
-                        raise DataNotFoundError('Could not find the rtfBody')
+                        raise DataNotFoundError('Could not find the rtfBody.')
 
-            # Save the attachments.
-            attachmentNames = [attachment.save(**kwargs) for attachment in self.attachments]
+            if not skipAttachments:
+                # Save the attachments.
+                attachmentNames = [attachment.save(**kwargs) for attachment in self.attachments]
 
             if not attachOnly:
-                # Determine the extension to use for the body.
-                fext = 'json' if _json else fext
-
                 with _open(str(path / ('message.' + fext)), mode) as f:
                     if _json:
                         emailObj = json.loads(self.getJson())
-                        emailObj['attachments'] = attachmentNames
+                        if not skipAttachments:
+                            emailObj['attachments'] = attachmentNames
 
                         f.write(inputToBytes(json.dumps(emailObj), 'utf-8'))
                     elif useHtml:
                         f.write(self.getSaveHtmlBody(**kwargs))
+                    elif usePdf:
+                        f.write(self.getSavePdfBody(**kwargs))
                     elif useRtf:
                         f.write(self.getSaveRtfBody(**kwargs))
                     else:
@@ -347,6 +370,58 @@ class MessageSigned(MessageSignedBase):
             return data
         else:
             return self.htmlBody
+
+    def getSavePdfBody(self, **kwargs) -> bytes:
+        """
+        Returns the PDF body that will be used in saving based on the arguments.
+
+        :param wkPath: Used to manually specify the path of the wkhtmltopdf
+            executable. If not specified, the function will try to find it.
+            Useful if wkhtmltopdf is not on the path. If :param pdf: is False,
+            this argument is ignored.
+        :param wkOptions: Used to specify additional options to wkhtmltopdf.
+            this must be a list or list-like object composed of strings and
+            bytes.
+        :param kwargs: Used to allow kwargs expansion in the save function.
+            Arguments absorbed by this are simply ignored.
+
+        :raises ExecutableNotFound: The wkhtmltopdf executable could not be
+            found.
+        :raises WKError: Something went wrong in creating the PDF body.
+        """
+        # Immediately try to find the executable.
+        wkPath = findWk(kwargs.get('wkPath'))
+
+        # First thing is first, we need to parse our wkOptions if
+        # they exist.
+        wkOptions = kwargs.get('wkOptions')
+        if wkOptions:
+            try:
+                # Try to convert to a list, whatever it is, and
+                # fail if it is not possible.
+                parsedWkOptions = [*wkOptions]
+            except TypeError:
+                raise TypeError(':param wkOptions: must be an iterable, not {type(wkOptions)}.')
+        else:
+            parsedWkOptions = []
+
+        # Confirm that all of our options we now have are either
+        # strings or bytes.
+        if not all(isinstance(option, (str, bytes)) for option in parsedWkOptions):
+            raise TypeError(':param wkOptions: must be an iterable of strings and bytes.')
+
+        # We call the program to convert the html, but give tell it
+        # the data will go in and come out through stdin and stdout,
+        # respectively. This way we don't have to write temporary
+        # files to the disk. We also ask that it be quiet about it.
+        process = subprocess.Popen([wkPath, *parsedWkOptions, '-', '-'], shell = True, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+        # Give the program the data and wait for the program to
+        # finish.
+        output = process.communicate(self.getSaveHtmlBody(**kwargs))
+        if process.returncode != 0:
+            raise WKError(output[1].decode('utf-8'))
+
+        return output[0]
 
     def getSaveRtfBody(self, **kwargs) -> bytes:
         """

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -63,21 +63,12 @@ class MSGFile(olefile.OleFileIO):
         """
         # Retrieve all the kwargs that we need.
         prefix = kwargs.get('prefix', '')
-        parentMsg = kwargs.get('parentMsg')
+        self.__parentMsg = kwargs.get('parentMsg')
+        # Verify it is a valid class.
+        if self.__parentMsg is not None and not isinstance(self.__parentMsg, MSGFile):
+            raise TypeError(':param parentMsg: must be an instance of MSGFile or a subclass.')
         filename = kwargs.get('filename', None)
         overrideEncoding = kwargs.get('overrideEncoding', None)
-
-        # Handle the parent msg file existing.
-        if parentMsg:
-            # Verify it is a valid class.
-            if not isinstance(parentMsg, MSGFile):
-                raise TypeError(':param parentMsg: must be an instance of MSGFile or a subclass.')
-            # Try to get the named properties and use that for our main
-            # instance.
-            try:
-                self.__named = parentMsg.named
-            except Exception:
-                pass
 
         # WARNING DO NOT MANUALLY MODIFY PREFIX. Let the program set it.
         self.__path = path
@@ -131,7 +122,7 @@ class MSGFile(olefile.OleFileIO):
         self.__prefixList = prefixl
         self.__prefixLen = len(prefixl)
         if prefix:
-            filename = self._getStringStream(prefixl[:-1] + ['__substg1.0_3001'], prefix=False)
+            filename = self._getStringStream(prefixl[:-1] + ['__substg1.0_3001'], prefix = False)
         if filename:
             self.filename = filename
         elif hasLen(path):
@@ -692,7 +683,17 @@ class MSGFile(olefile.OleFileIO):
         try:
             return self.__named
         except AttributeError:
-            self.__named = Named(self)
+            self.__named = None
+            # Handle the parent msg file existing.
+            if self.__parentMsg:
+                # Try to get the named properties and use that for our main
+                # instance.
+                try:
+                    self.__named = self.__parentMsg.named
+                except Exception:
+                    pass
+            if not self.__named:
+                self.__named = Named(self)
             return self.__named
 
     @property

--- a/extract_msg/recipient.py
+++ b/extract_msg/recipient.py
@@ -15,7 +15,7 @@ class Recipient:
     """
     Contains the data of one of the recipients in an msg file.
     """
-    
+
     def __init__(self, _dir, msg):
         self.__msg = msg # Allows calls to original msg file.
         self.__dir = _dir

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -600,7 +600,6 @@ def openMsg(path, **kwargs):
     :raises UnrecognizedMSGTypeError: if the type is not recognized.
     """
     from .appointment import Appointment
-    from .attachment import Attachment
     from .contact import Contact
     from .message import Message
     from .msg import MSGFile

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -396,8 +396,12 @@ def injectHtmlHeader(msgFile, prepared : bool = False) -> bytes:
                 # insert it.
                 if correctedHtml.find('head'):
                     correctedHtml.find('head').insert_after(bodyTag)
-                else:
+                elif correctedHtml.find('footer'):
                     correctedHtml.find('footer').insert_before(bodyTag)
+                else:
+                    # Neither a head or a body are present, so just append it to
+                    # the main tag.
+                    htmlTag.append(bodyTag)
             else:
                 # If there is no <html>, <head>, <footer>, or <body> tag, then
                 # we just add the tags to the beginning and end of the data and

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -183,6 +183,13 @@ def getCommandArgs(args):
     # --html
     parser.add_argument('--html', dest='html', action='store_true',
                         help='Sets whether the output should be HTML. If this is not possible, will error.')
+    # --pdf
+    parser.add_argument('--pdf', dest = 'pdf', action='store_true',
+                        help='Saves the body as a PDF. If this is not possible, will error.')
+
+    # --wk-path
+    parser.add_argument('--wk-path', desk = 'wkPath'
+                        help='Overrides the path for finding wkhtmltopdf.')
     # --prepared-html
     parser.add_argument('--prepared-html', dest='preparedHtml', action='store_true',
                         help='When used in conjunction with --html, sets whether the HTML output should be prepared for embedded attachments.')
@@ -214,8 +221,8 @@ def getCommandArgs(args):
     options = parser.parse_args(args)
 
     # Check if more than one of the following arguments has been specified
-    if options.html + options.rtf + options.json + options.raw + options.attachmentsOnly > 1:
-       raise IncompatibleOptionsError('Only one of these options may be selected at a time: --html, --json, --raw, --rtf, --attachments-only')
+    if options.html + options.rtf + options.json + options.raw + options.pdf + options.attachmentsOnly > 1:
+       raise IncompatibleOptionsError('Only one of these options may be selected at a time: --html, --json, --raw, --rtf, --attachments-only, --pdf')
 
     if options.dev or options.file_logging:
         options.verbose = True

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -246,6 +246,9 @@ def getCommandArgs(args):
     # --glob
     inputFormat.add_argument('--glob', '--wildcard', dest='glob', action='store_true',
                         help='Interpret all paths as having wildcards. Incompatible with --out-name.')
+    # --ignore-rtfde
+    parser.add_argument('--ignore-rtfde', dest='ignoreRtfDeErrors', action='store_true',
+                        help='Ignores all errors thrown from RTFDE when trying to save. Useful for allowing fallback to continue when an exception happens.')
     # --progress
     parser.add_argument('--progress', dest='progress', action='store_true',
                         help='Shows what file the program is currently working on during it\'s progress.')
@@ -640,6 +643,8 @@ def openMsg(path, **kwargs):
         of an error when parsing the attachments.
     :param recipientSeparator: Optional, Separator string to use between
         recipients.
+    :param ignoreRtfDeErrors: Optional, specifies that any errors that occur
+        from the usage of RTFDE should be ignored (default: False).
 
     If :param strict: is set to `True`, this function will raise an exception
     when it cannot identify what MSGFile derivitive to use. Otherwise, it will

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ebcdic>=1.1.1
 beautifulsoup4>=4.10.0
 RTFDE>=0.0.2
 mailbits>=0.2.1
+chardet>=4.0.0


### PR DESCRIPTION
**v0.34.0**
* [[TeamMsgExtractor #102](https://github.com/TeamMsgExtractor/msg-extractor/issues/102)] Added the option to directly save body to pdf. This requires that you either have wkhtmltopdf on your path or that you provide a path directly to it in order to work. Simply pass `pdf = True` to save to turn it on. More details in the doc for the save function. You can also do this from the command line using the `--pdf` option, incompatible with other body types.
* Added `--glob` option for allowing you to provide an msg path that will evaluate wildcards.
* Removed per-file output names as they weren't actually functional and currently add too much complexity. If anyone knows a way to handle it directly with `argparse` let me know.
* Added `chardet` as a requirement to help work around an error in `RTFDE`.
* Looking into some of the unsupported encodings revealed at least one to be supported, but was missed due to the name not being registered as an alias.
* Fixed a bug that prevented an HTML body from the plain text body when it couldn't be generated any other way. This happened when the RTF body existed and the plain text body existed, but the RTF body was not encapsulated HTML.
* Due to several of the issues with RTFDE preventing saving due to exceptions, the option `ignoreRtfDeErrors` has been added to the `MessageBase` class and `openMsg`. It can also be enabled from the command line with `--ignore-rtfde`. This option will make it so all exceptions will be silenced from the module.