### PR TITLE
Version 0.34.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **0.34.2**
-* TODO
+* [[TeamMsgExtractor #267](https://github.com/TeamMsgExtractor/msg-extractor/issues/267)] Fixed issue that caused signed messages that were .eml files to have their data field *not* be a bytes instance. This field will now *always* be bytes. If a problem making it bytes occurs, an exception will be raised to give you brief details.
+* Added function `utils.unwrapMultipart` that takes a multipart message and acquires a plain text body, an HTML body, and a list of attachments from it. These attachments are returned as `dict`s that can easily be converted to `SignedAttachment`s. It replaces the logic `mailbits` was being used for, and as such `mailbits` is no longer required. The module may be reintroduced in the future.
+* Added new property `emailMessage` to `SignedAttachment`, which returns the email `Message` instance used to get data for the attachment.
 
 **0.34.1**
 * Added convenience function `utils.openMsgBulk` (imported to `extract_msg` namespace) for opening message paths with wildcards. Allows you to open several messages with one function, returning a list of the opened messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**0.34.2**
+* TODO
+
 **0.34.1**
 * Added convenience function `utils.openMsgBulk` (imported to `extract_msg` namespace) for opening message paths with wildcards. Allows you to open several messages with one function, returning a list of the opened messages.
 * Added convenience function `utils.unwrapMsg` which recurses through an `MSGFile` and it's attachments, creating a series of linear structures stored in a dictionary. Useful for analyzing, saving, etc. all messages and attachments down through the structure without having to recurse yourself.

--- a/README.rst
+++ b/README.rst
@@ -219,8 +219,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.34.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.34.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.34.2-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.34.2/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2022-06-14'
-__version__ = '0.34.1'
+__version__ = '0.34.2'
 
 import logging
 

--- a/extract_msg/signed_attachment.py
+++ b/extract_msg/signed_attachment.py
@@ -1,3 +1,4 @@
+import email
 import logging
 import os
 import pathlib
@@ -12,11 +13,19 @@ logger.addHandler(logging.NullHandler())
 
 
 class SignedAttachment:
-    def __init__(self, msg, data : bytes, name : str, mime : str):
+    def __init__(self, msg, data : bytes, name : str, mimetype : str, node : email.message.Message):
+        """
+        :param msg: The msg file this attachment is associated with.
+        :param data: The bytes that compose this attachment.
+        :param name: The reported name of the attachment.
+        :param mimetype: The reported mimetype of the attachment.
+        :param node: The email Message instance for this node.
+        """
         self.__data = data
         self.__name = name
-        self.__mime = mime
+        self.__mimetype = mimetype
         self.__msg = msg
+        self.__node = node
 
     def save(self, **kwargs):
         """
@@ -121,20 +130,42 @@ class SignedAttachment:
 
     @property
     def data(self) -> bytes:
+        """
+        The bytes that compose this attachment.
+        """
         return self.__data
 
     @property
-    def mimetype(self) -> str:
-        return self.__mime
+    def emailMessage(self) -> email.message.Message:
+        """
+        The email Message instance that is the source for this attachment.
+        """
+        return self.__node
 
     @property
-    def msg(self):
+    def mimetype(self) -> str:
+        """
+        The reported mimetype of the attachment.
+        """
+        return self.__mimetype
+
+    @property
+    def msg(self) -> "MSGFile":
+        """
+        The MSGFile instance this attachment belongs to.
+        """
         return self.__msg
 
     @property
-    def name(self):
+    def name(self) -> str:
+        """
+        The reported name of this attachment.
+        """
         return self.__name
 
     @property
-    def type(self):
+    def type(self) -> AttachmentType:
+        """
+        The AttachmentType.
+        """
         return AttachmentType.SIGNED

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ compressed_rtf>=1.0.6
 ebcdic>=1.1.1
 beautifulsoup4>=4.10.0
 RTFDE>=0.0.2
-mailbits>=0.2.1
 chardet>=4.0.0


### PR DESCRIPTION
**0.34.2**
* [[TeamMsgExtractor #267](https://github.com/TeamMsgExtractor/msg-extractor/issues/267)] Fixed issue that caused signed messages that were .eml files to have their data field *not* be a bytes instance. This field will now *always* be bytes. If a problem making it bytes occurs, an exception will be raised to give you brief details.
* Added function `utils.unwrapMultipart` that takes a multipart message and acquires a plain text body, an HTML body, and a list of attachments from it. These attachments are returned as `dict`s that can easily be converted to `SignedAttachment`s. It replaces the logic `mailbits` was being used for, and as such `mailbits` is no longer required. The module may be reintroduced in the future.
* Added new property `emailMessage` to `SignedAttachment`, which returns the email `Message` instance used to get data for the attachment.