### PR TITLE
Version 0.34.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-**0.34.2**
+**v0.34.3**
+* Fixed issue that may have caused other olefile types to raise the wrong type of error when passed to `openMsg`.
+* Fixed issues with changelog format.
+* Fixed issue that caused progress to sometimes break the main loop when a file had Unicode characters if the console it was writing to didn't support them.
+* Added option to `MessageBase` (and subsequently `openMsg`) that allows you to override the code being used for deencapsulation. See `MessageBase.__init__` for details on how to create an override function.
+
+**v0.34.2**
 * [[TeamMsgExtractor #267](https://github.com/TeamMsgExtractor/msg-extractor/issues/267)] Fixed issue that caused signed messages that were .eml files to have their data field *not* be a bytes instance. This field will now *always* be bytes. If a problem making it bytes occurs, an exception will be raised to give you brief details.
 * Added function `utils.unwrapMultipart` that takes a multipart message and acquires a plain text body, an HTML body, and a list of attachments from it. These attachments are returned as `dict`s that can easily be converted to `SignedAttachment`s. It replaces the logic `mailbits` was being used for, and as such `mailbits` is no longer required. The module may be reintroduced in the future.
 * Added new property `emailMessage` to `SignedAttachment`, which returns the email `Message` instance used to get data for the attachment.
 
-**0.34.1**
+**v0.34.1**
 * Added convenience function `utils.openMsgBulk` (imported to `extract_msg` namespace) for opening message paths with wildcards. Allows you to open several messages with one function, returning a list of the opened messages.
 * Added convenience function `utils.unwrapMsg` which recurses through an `MSGFile` and it's attachments, creating a series of linear structures stored in a dictionary. Useful for analyzing, saving, etc. all messages and attachments down through the structure without having to recurse yourself.
 * Fixed an issue that would cause signed attachments to not properly generate.

--- a/README.rst
+++ b/README.rst
@@ -219,8 +219,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.34.2-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.34.2/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.34.3-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.34.3/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-06-14'
-__version__ = '0.34.2'
+__date__ = '2022-06-15'
+__version__ = '0.34.3'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -70,16 +70,24 @@ def main() -> None:
         }
 
         for x in args.msgs:
-            try:
-                if args.progress:
+            if args.progress:
+                # This may throw an error sometimes and not othertimes.
+                # Unclear why, so let's just silence it.
+                try:
                     print(f'Saving file "{x}"...')
+                except UnicodeEncodeError:
+                    print(f'Saving file "{repr(x)}" (failed to print without repr)...')
+            try:
                 with utils.openMsg(x, **openKwargs) as msg:
                     if args.dumpStdout:
                         print(msg.body)
                     else:
                         msg.save(**kwargs)
             except Exception as e:
-                print(f'Error with file "{x}": {traceback.format_exc()}')
+                try:
+                    print(f'Error with file "{x}": {traceback.format_exc()}')
+                except UnicodeEncodeError:
+                    print(f'Error with file "{repr(x)}": {traceback.format_exc()}')
 
 
 if __name__ == '__main__':

--- a/extract_msg/enums.py
+++ b/extract_msg/enums.py
@@ -22,6 +22,14 @@ class AttachmentType(enum.Enum):
     WEB = 2
     SIGNED = 3
 
+class DeencapType(enum.Enum):
+    """
+    Enum to specify to custom deencapsulation functions the type of data being
+    requested.
+    """
+    PLAIN = 0
+    HTML = 1
+
 class DisplayType(enum.Enum):
     MAILUSER = 0x0000
     DISTLIST = 0x0001

--- a/extract_msg/exceptions.py
+++ b/extract_msg/exceptions.py
@@ -31,6 +31,16 @@ class DataNotFoundError(Exception):
     """
     pass
 
+class DeencapMalformedData(Exception):
+    """
+    Data to deencapsulate was malformed in some way.
+    """
+
+class DeencapNotEncapsulated(Exception):
+    """
+    Data to deencapsulate did not contain any encapsulated data.
+    """
+
 class ExecutableNotFound(Exception):
     """
     Could not find the specified executable.


### PR DESCRIPTION
**v0.34.3**
* Fixed issue that may have caused other olefile types to raise the wrong type of error when passed to `openMsg`.
* Fixed issues with changelog format.
* Fixed issue that caused progress to sometimes break the main loop when a file had Unicode characters if the console it was writing to didn't support them.
* Added option to `MessageBase` (and subsequently `openMsg`) that allows you to override the code being used for deencapsulation. See `MessageBase.__init__` for details on how to create an override function.