### PR TITLE
Version 0.35.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.35.2**
+* Made a change to the argument handling for `--no-folders`. Since it requires `--attachmentsOnly` to work, I simply made it error when it's not given to avoid confusion.
+* Updated README.
+
 **v0.35.1**
 * Fixed a few property conflicts that I missed in the last release (forgot to run the helper script before releasing).
 
@@ -51,7 +55,7 @@
 * Added option `--skip-embedded` to the command line to skip saving embedded MSG files.
 * Added option `skipEmbedded` to `Attachment.save` (and all other related save methods that call it) to skip saving an embedded MSG file.
 * Changed `__main__` so that it opens the zip file there instead of relying on everything it calls to do it again and again.
-* Changed the behavior of `--verbose` to allow it to be stacked for more verboseness. Specifying it once turns on warnings, twice for info, and three times for debug. Not specifying it only turns on error logging.
+* Changed the behavior of `--verbose` to allow it to be stacked for more verbosity. Specifying it once turns on warnings, twice for info, and three times for debug. Not specifying it only turns on error logging.
 
 **v0.34.3**
 * Fixed issue that may have caused other olefile types to raise the wrong type of error when passed to `openMsg`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 **v0.35.2**
 * Made a change to the argument handling for `--no-folders`. Since it requires `--attachmentsOnly` to work, I simply made it error when it's not given to avoid confusion.
 * Updated README.
+* Added `-v` to be used instead of `--verbose`. This allows you to do `-vvv` for verbosity level 3.
 
 **v0.35.1**
 * Fixed a few property conflicts that I missed in the last release (forgot to run the helper script before releasing).

--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,7 @@ Additionally, this module has the following extras which can be optionally
 installed:
 
 * ``all``: Installs all of the extras.
-* ``mime``: Installs dependency used for mimetype generation when a mimetype is
-    not specified.
+* ``mime``: Installs dependency used for mimetype generation when a mimetype is not specified.
 
 Todo
 ----

--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,7 @@ or you can include this in your list of python dependencies with:
 
 Additionally, this module has the following extras which can be optionally
 installed:
+
 * `all`: Installs all of the extras.
 * `mime`: Installs dependency used for mimetype generation when a mimetype is
     not specified.

--- a/README.rst
+++ b/README.rst
@@ -179,8 +179,8 @@ or you can include this in your list of python dependencies with:
 Additionally, this module has the following extras which can be optionally
 installed:
 
-* `all`: Installs all of the extras.
-* `mime`: Installs dependency used for mimetype generation when a mimetype is
+* ``all``: Installs all of the extras.
+* ``mime``: Installs dependency used for mimetype generation when a mimetype is
     not specified.
 
 Todo

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,12 @@ or you can include this in your list of python dependencies with:
        dependency_links=['https://github.com/TeamMsgExtractor/msg-extractor/zipball/master'],
    )
 
+Additionally, this module has the following extras which can be optionally
+installed:
+* `all`: Installs all of the extras.
+* `mime`: Installs dependency used for mimetype generation when a mimetype is
+    not specified.
+
 Todo
 ----
 
@@ -220,8 +226,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.35.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.35.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.35.2-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.35.2/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ refer to the usage information provided from the program's help dialog:
       --validate            Turns on file validation mode. Turns off regular file output.
       --json                Changes to write output files as json.
       --file-logging        Enables file logging. Implies --verbose level 1.
-      --verbose             Turns on console logging.
+      -v, --verbose         Turns on console logging. Specify more than once for higher verbosity.
       --log LOG             Set the path to write the file log to.
       --config CONFIGPATH   Set the path to load the logging config from.
       --out OUTPATH         Set the folder to use for the program output. (Default: Current directory)

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2022-07-11'
-__version__ = '0.35.1'
+__version__ = '0.35.2'
 
 import logging
 

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -294,7 +294,7 @@ def getCommandArgs(args):
                            help='Specify to only save attachments from an msg file.')
     # --no-folders
     parser.add_argument('--no-folders', dest='noFolders', action='store_true',
-                        help='When used with --attachments-only, stores everything in the location specified by --out. Incompatible with --out-name.')
+                        help='Stores everything in the location specified by --out. Requires --attachments-only and is incompatible with --out-name.')
 
     parser.add_argument('--skip-embedded', dest = 'skipEmbedded', action='store_true',
                         help='Skips all embedded MSG files when saving attachments.')
@@ -367,7 +367,7 @@ def getCommandArgs(args):
     if options.outName and options.fileArgs and len(options.fileArgs) > 0:
         raise ValueError('--out-name is not supported when saving multiple MSG files.')
 
-
+    # Handle the verbosity level.
     if options.verbose == 0:
         options.logLevel = logging.ERROR
     elif options.verbose == 1:
@@ -377,6 +377,9 @@ def getCommandArgs(args):
     else:
         options.logLevel = 5
 
+    # If --no-folders is turned on but --attachments-only is not, error.
+    if options.noFolders and not options.attachmentsOnly:
+        raise ValueError('--no-folders requires the --attachments-only option.')
 
     return options
 

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -242,8 +242,8 @@ def getCommandArgs(args):
     parser.add_argument('--file-logging', dest='fileLogging', action='store_true',
                         help='Enables file logging. Implies --verbose level 1.')
     # --verbose
-    parser.add_argument('--verbose', dest='verbose', action='count', default=0,
-                        help='Turns on console logging.')
+    parser.add_argument('-v', '--verbose', dest='verbose', action='count', default=0,
+                        help='Turns on console logging. Specify more than once for higher verbosity.')
     # --log PATH
     parser.add_argument('--log', dest='log',
                         help='Set the path to write the file log to.')


### PR DESCRIPTION
**v0.35.2**
* Made a change to the argument handling for `--no-folders`. Since it requires `--attachmentsOnly` to work, I simply made it error when it's not given to avoid confusion.
* Updated README.
* Added `-v` to be used instead of `--verbose`. This allows you to do `-vvv` for verbosity level 3.