### PR TITLE
Version 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v0.35.4**
+* Improved type hints to tell when a function may not return anything.
+* Added support for the `reportTag` property to `MessageBase`.
+* Fixed a few minor issues in some properties.
+* Fixed `Attachment.save` returning a `pathlib.Path` object instead of a `str` after the conversion to `pathlib`.
+
 **v0.35.3**
 * [[TeamMsgExtractor #280](https://github.com/TeamMsgExtractor/msg-extractor/issues/280)] Fix typing issue in `message_base.py`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-**v0.35.4**
+**v0.36.0**
 * Improved type hints to tell when a function may not return anything.
 * Added support for the `reportTag` property to `MessageBase`. I noticed this was one of the properties for `IPM.Outlook.Recall` so I decided to implement it. I'll work on ensuring all of `[MS-OXOMSG]` and `[MS-OXCMSG]` are implemented at a later date, including splitting off `REPORT` into it's own class, because it is it's own class.
 * Fixed a few minor issues in some properties. Mostly some `bool` returning properties should have been returning False when they were not found instead of None. Ones that may return None are specifically typed as optional in the source code. Unfortunately using the `help` command doesn't seem to show the return type for properties for me at least on Python 3.9 and below.
 * Fixed `Attachment.save` returning a `pathlib.Path` object instead of a `str` after the conversion to `pathlib`.
 * Added code to allow `pathlib` objects in `utils.openMsgBulk`. It uses `glob.glob` which *cannot* take a `pathlib` object.
+* Removed `PermanentEntryID` from `EntryID.autoCreate`. It shares a provider ID with `AddressBookEntryID`, and as such would never generate from it anyways. If you specifically need a `PermanentEntryID` you will have to instantiate it manually. Additionally, the entry has been removed from `enums.EntryIDType`.
+* Fixed the GUIDs for some of the EntryID structures being returned as bytes instead of a standard GUID string. This is considered a breaking change and is the reason for the full version increase.
+* Improved consistency of properties (the Python kind, not the MSG kind) so that properties for the raw data used to create an instance will all use the same name. Not all classes have this, but the ones that do will now all use `rawData` as the property name.
+* Fixed the properties header being read in a way that actually swapped the values in it.
+* Modified `MSGFile` to use the same name for Properties instances as all other classes. `MSGFile.mainProperties` will currently raise a `DeprecationWarning` instead of outright failing to help ease the transition. Use `MSGFile.props` instead.
 
 **v0.35.3**
 * [[TeamMsgExtractor #280](https://github.com/TeamMsgExtractor/msg-extractor/issues/280)] Fix typing issue in `message_base.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 **v0.35.4**
 * Improved type hints to tell when a function may not return anything.
-* Added support for the `reportTag` property to `MessageBase`.
-* Fixed a few minor issues in some properties.
+* Added support for the `reportTag` property to `MessageBase`. I noticed this was one of the properties for `IPM.Outlook.Recall` so I decided to implement it. I'll work on ensuring all of `[MS-OXOMSG]` and `[MS-OXCMSG]` are implemented at a later date, including splitting off `REPORT` into it's own class, because it is it's own class.
+* Fixed a few minor issues in some properties. Mostly some `bool` returning properties should have been returning False when they were not found instead of None. Ones that may return None are specifically typed as optional in the source code. Unfortunately using the `help` command doesn't seem to show the return type for properties for me at least on Python 3.9 and below.
 * Fixed `Attachment.save` returning a `pathlib.Path` object instead of a `str` after the conversion to `pathlib`.
+* Added code to allow `pathlib` objects in `utils.openMsgBulk`. It uses `glob.glob` which *cannot* take a `pathlib` object.
 
 **v0.35.3**
 * [[TeamMsgExtractor #280](https://github.com/TeamMsgExtractor/msg-extractor/issues/280)] Fix typing issue in `message_base.py`.

--- a/README.rst
+++ b/README.rst
@@ -226,8 +226,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.35.4-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.35.4/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.36.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/README.rst
+++ b/README.rst
@@ -226,8 +226,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.35.3-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.35.3/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.35.4-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.35.4/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-07-12'
-__version__ = '0.35.4'
+__date__ = '2022-07-15'
+__version__ = '0.36.0'
 
 import logging
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-07-11'
-__version__ = '0.35.3'
+__date__ = '2022-07-12'
+__version__ = '0.35.4'
 
 import logging
 

--- a/extract_msg/appointment.py
+++ b/extract_msg/appointment.py
@@ -1,5 +1,7 @@
 import datetime
 
+from typing import Optional
+
 from . import constants
 from .enums import AppointmentStateFlag, BusyStatus, RecurPatternType, ResponseStatus
 from .calendar import Calendar
@@ -21,17 +23,17 @@ class AppointmentMeeting(Calendar):
         Indicates to the organizer that there are counter proposals that have
         not been accepted or rejected by the organizer.
         """
-        return self._ensureSetNamed('_appointmentCounterProposal', '8257', constants.PSETID_APPOINTMENT)
+        return self._ensureSetNamed('_appointmentCounterProposal', '8257', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
-    def appointmentLastSequence(self) -> int:
+    def appointmentLastSequence(self) -> Optional[int]:
         """
         The last sequence number that was sent to any attendee.
         """
         return self._ensureSetNamed('_appointmentLastSequence', '8203', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentProposalNumber(self) -> int:
+    def appointmentProposalNumber(self) -> Optional[int]:
         """
         The number of attendees who have sent counter propostals that have not
         been accepted or rejected by the organizer.
@@ -39,14 +41,14 @@ class AppointmentMeeting(Calendar):
         return self._ensureSetNamed('_appointmentProposalNumber', '8259', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentReplyName(self) -> datetime.datetime:
+    def appointmentReplyName(self) -> Optional[datetime.datetime]:
         """
         The user who last replied to the meeting request or meeting update.
         """
         return self._ensureSetNamed('_appointmentReplyName', '8230', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentReplyTime(self) -> datetime.datetime:
+    def appointmentReplyTime(self) -> Optional[datetime.datetime]:
         """
         The date and time at which the attendee responded to a received Meeting
         Request object of Meeting Update object in UTC.
@@ -54,7 +56,7 @@ class AppointmentMeeting(Calendar):
         return self._ensureSetNamed('_appointmentReplyTime', '8220', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentSequenceTime(self) -> datetime.datetime:
+    def appointmentSequenceTime(self) -> Optional[datetime.datetime]:
         """
         The date and time at which the appointmentSequence property was last
         modified.
@@ -71,7 +73,7 @@ class AppointmentMeeting(Calendar):
         A value of False indicates that the value of the location property is
         not automatically set.
         """
-        return self._ensureSetNamed('_autoFillLocation', '823A', constants.PSETID_APPOINTMENT, overrideClass = bool)
+        return self._ensureSetNamed('_autoFillLocation', '823A', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
     def fInvited(self) -> bool:
@@ -160,10 +162,10 @@ class AppointmentMeeting(Calendar):
         Attempts to determine if the object is a Meeting. True if meeting, False
         if appointment.
         """
-        return AppointmentStateFlag.MEETING in self.appointmentStateFlags
+        return self.appointmentStateFlags and AppointmentStateFlag.MEETING in self.appointmentStateFlags
 
     @property
-    def originalStoreEntryID(self) -> EntryID:
+    def originalStoreEntryID(self) -> Optional[EntryID]:
         """
         The EntryID of the delegator's message store.
         """

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -5,6 +5,8 @@ import random
 import string
 import zipfile
 
+from typing import Optional, Union
+
 from . import constants
 from .attachment_base import AttachmentBase
 from .enums import AttachmentType
@@ -51,7 +53,7 @@ class Attachment(AttachmentBase):
         else:
             raise TypeError('Unknown attachment type.')
 
-    def getFilename(self, **kwargs):
+    def getFilename(self, **kwargs) -> str:
         """
         Returns the filename to use for the attachment.
 
@@ -71,13 +73,14 @@ class Attachment(AttachmentBase):
             filename = customFilename
         else:
             # If not...
-            # Check if user wants to save the file under the Content-id
+            # Check if user wants to save the file under the Content-ID.
             if kwargs.get('contentId', False):
                 filename = self.cid
-            # If filename is None at this point, use long filename as first preference
+            # If filename is None at this point, use long filename as first
+            # preference.
             if not filename:
                 filename = self.longFilename
-            # Otherwise use the short filename
+            # Otherwise use the short filename.
             if not filename:
                 filename = self.shortFilename
             # Otherwise just make something up!
@@ -86,7 +89,7 @@ class Attachment(AttachmentBase):
 
         return filename
 
-    def regenerateRandomName(self):
+    def regenerateRandomName(self) -> str:
         """
         Used to regenerate the random filename used if the attachment cannot
         find a usable filename.
@@ -95,7 +98,7 @@ class Attachment(AttachmentBase):
                    ''.join(random.choice(string.ascii_uppercase + string.digits)
                            for _ in range(5)) + '.bin', 'ascii')
 
-    def save(self, **kwargs):
+    def save(self, **kwargs) -> Optional[Union[str, 'MSGFile']]:
         """
         Saves the attachment data.
 
@@ -199,7 +202,7 @@ class Attachment(AttachmentBase):
             if _zip and createdZip:
                 _zip.close()
 
-            return fullFilename
+            return str(fullFilename)
         else:
             self.saveEmbededMessage(**kwargs)
 
@@ -209,7 +212,7 @@ class Attachment(AttachmentBase):
 
             return self.msg
 
-    def saveEmbededMessage(self, **kwargs):
+    def saveEmbededMessage(self, **kwargs) -> None:
         """
         Seperate function from save to allow it to easily be overridden by a
         subclass.
@@ -217,14 +220,14 @@ class Attachment(AttachmentBase):
         self.data.save(**kwargs)
 
     @property
-    def data(self):
+    def data(self) -> Optional[Union[bytes, 'MSGFile']]:
         """
         Returns the attachment data.
         """
         return self.__data
 
     @property
-    def randomFilename(self):
+    def randomFilename(self) -> str:
         """
         Returns the random filename to be used by this attachment.
         """

--- a/extract_msg/attachment_base.py
+++ b/extract_msg/attachment_base.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 from functools import partial
+from typing import Optional
 
 from . import constants
 from .enums import AttachmentType, PropertiesType
@@ -144,10 +145,10 @@ class AttachmentBase:
             setattr(self, variable, value)
             return value
 
-    def _getStream(self, filename):
+    def _getStream(self, filename) -> Optional[bytes]:
         return self.__msg._getStream([self.__dir, filename])
 
-    def _getStringStream(self, filename):
+    def _getStringStream(self, filename) -> Optional[str]:
         """
         Gets a string representation of the requested filename.
         Checks for both ASCII and Unicode representations and returns
@@ -241,7 +242,7 @@ class AttachmentBase:
         return self.__msg.existsTypedProperty(id, self.__dir, _type, True, self.__props)
 
     @property
-    def attachmentEncoding(self) -> bytes:
+    def attachmentEncoding(self) -> Optional[bytes]:
         """
         The encoding information about the attachment object. Will return
         b'*\x86H\x86\xf7\x14\x03\x0b\x01' if encoded in MacBinary format,
@@ -250,7 +251,7 @@ class AttachmentBase:
         return self._ensureSet('_attachmentEncoding', '__substg1.0_37020102', False)
 
     @property
-    def additionalInformation(self) -> str:
+    def additionalInformation(self) -> Optional[str]:
         """
         The additional information about the attachment. This property MUST be
         an empty string if attachmentEncoding is not set. Otherwise it MUST be
@@ -261,7 +262,7 @@ class AttachmentBase:
         return self._ensureSet('_additionalInformation', '__substg1.0_370F')
 
     @property
-    def cid(self) -> str:
+    def cid(self) -> Optional[str]:
         """
         Returns the Content ID of the attachment, if it exists.
         """
@@ -278,7 +279,7 @@ class AttachmentBase:
         return self.__dir
 
     @property
-    def exceptionReplaceTime(self) -> datetime.datetime:
+    def exceptionReplaceTime(self) -> Optional[datetime.datetime]:
         """
         The original date and time at which the instance in the recurrence
         pattern would have occurred if it were not an exception.
@@ -288,7 +289,7 @@ class AttachmentBase:
         return self._ensureSetProperty('_exceptionReplaceTime', '7FF90040')
 
     @property
-    def extension(self) -> str:
+    def extension(self) -> Optional[str]:
         """
         The reported extension for the file.
         """
@@ -299,7 +300,7 @@ class AttachmentBase:
         """
         Indicates whether an Attachment object is hidden from the end user.
         """
-        return self._ensureSetProperty('_hidden', '7FFE000B')
+        return self._ensureSetProperty('_hidden', '7FFE000B', overrideClass = bool, preserveNone = False)
 
     @property
     def isAttachmentContactPhoto(self) -> bool:
@@ -309,14 +310,14 @@ class AttachmentBase:
         return self._ensureSetProperty('_isAttachmentContactPhoto', '7FFF000B', overrideClass = bool, preserveNone = False)
 
     @property
-    def longFilename(self) -> str:
+    def longFilename(self) -> Optional[str]:
         """
         Returns the long file name of the attachment, if it exists.
         """
         return self._ensureSet('_longFilename', '__substg1.0_3707')
 
     @property
-    def mimetype(self) -> str:
+    def mimetype(self) -> Optional[str]:
         """
         The content-type mime header of the attachment, if specified.
         """
@@ -330,7 +331,7 @@ class AttachmentBase:
         return self.__msg
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         """
         The best name available for the file. Uses long filename before short.
         """
@@ -344,7 +345,7 @@ class AttachmentBase:
         return self.__namedProperties
 
     @property
-    def payloadClass(self) -> str:
+    def payloadClass(self) -> Optional[str]:
         """
         The class name of an object that can display the contents of the
         message.
@@ -359,7 +360,7 @@ class AttachmentBase:
         return self.__props
 
     @property
-    def renderingPosition(self) -> int:
+    def renderingPosition(self) -> Optional[int]:
         """
         The offset, in redered characters, to use when rendering the attachment
         within the main message text. A value of 0xFFFFFFFF indicates a hidden
@@ -368,7 +369,7 @@ class AttachmentBase:
         return self._ensureSetProperty('_renderingPosition', '370B0003')
 
     @property
-    def shortFilename(self) -> str:
+    def shortFilename(self) -> Optional[str]:
         """
         Returns the short file name of the attachment, if it exists.
         """

--- a/extract_msg/calendar.py
+++ b/extract_msg/calendar.py
@@ -1,6 +1,6 @@
 import datetime
 
-from typing import Set
+from typing import Optional, Set
 
 from . import constants
 from .calendar_base import CalendarBase
@@ -13,14 +13,14 @@ class Calendar(CalendarBase):
     """
 
     @property
-    def clientIntent(self) -> Set[ClientIntentFlag]:
+    def clientIntent(self) -> Optional[Set[ClientIntentFlag]]:
         """
         A set of the actions a user has taken on a Meeting object.
         """
         return self._ensureSetNamed('_clientIntent', '0015', constants.PSETID_CALENDAR_ASSISTANT, overrideClass = ClientIntentFlag.fromBits)
 
     @property
-    def fExceptionalAttendees(self) -> bool:
+    def fExceptionalAttendees(self) -> Optional[bool]:
         """
         Indicates that it is a Recurring Calendar object with one or more
         excpetions and that at least one of the Exception Embedded Message
@@ -32,7 +32,7 @@ class Calendar(CalendarBase):
         return self._ensureSetNamed('_fExceptionalAttendees', '822B', constants.PSETID_APPOINTMENT)
 
     @property
-    def reminderDelta(self) -> int:
+    def reminderDelta(self) -> Optional[int]:
         """
         The interval, in minutes, between the time at which the reminder first
         becomes overdue and the start time of the Calendar object.
@@ -40,7 +40,7 @@ class Calendar(CalendarBase):
         return self._ensureSetNamed('_reminderDelta', '8501', constants.PSETID_COMMON)
 
     @property
-    def reminderFileParameter(self) -> str:
+    def reminderFileParameter(self) -> Optional[str]:
         """
         The full path (MAY only specify the file name) of the sound that a
         client SHOULD play when the reminder for the Message Object becomes
@@ -54,7 +54,7 @@ class Calendar(CalendarBase):
         Specifies if clients SHOULD respect the value of the reminderPlaySound
         property and the reminderFileParameter property.
         """
-        return self._ensureSetNamed('_reminderOverride', '851C', constants.PSETID_COMMON)
+        return self._ensureSetNamed('_reminderOverride', '851C', constants.PSETID_COMMON, overrideClass = bool, preserveNone = False)
 
     @property
     def reminderPlaySound(self) -> bool:
@@ -62,24 +62,24 @@ class Calendar(CalendarBase):
         Specified that the cliebnt should play a sound when the reminder becomes
         overdue.
         """
-        return self._ensureSetNamed('_reminderPlaySound', '851E', constants.PSETID_COMMON)
+        return self._ensureSetNamed('_reminderPlaySound', '851E', constants.PSETID_COMMON, overrideClass = bool, preserveNone = False)
 
     @property
     def reminderSet(self) -> bool:
         """
         Specifies whether a reminder is set on the object.
         """
-        return self._ensureSetNamed('_reminderSet', '8503', constants.PSETID_COMMON)
+        return self._ensureSetNamed('_reminderSet', '8503', constants.PSETID_COMMON, overrideClass = bool, preserveNone = False)
 
     @property
-    def reminderSignalTime(self) -> datetime.datetime:
+    def reminderSignalTime(self) -> Optional[datetime.datetime]:
         """
         The point in time when a reminder transitions from pending to overdue.
         """
         return self._ensureSetNamed('_reminderSignalTime', '8560', constants.PSETID_COMMON)
 
     @property
-    def reminderTime(self) -> datetime.datetime:
+    def reminderTime(self) -> Optional[datetime.datetime]:
         """
         The time after which the user would be late.
         """

--- a/extract_msg/calendar_base.py
+++ b/extract_msg/calendar_base.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 
-from typing import List, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 from . import constants
 from .enums import AppointmentAuxilaryFlag, AppointmentColor, AppointmentStateFlag, BusyStatus, IconIndex, MeetingRecipientType, ResponseStatus
@@ -22,7 +22,7 @@ class CalendarBase(MessageBase):
     Common base for all Appointment and Meeting objects.
     """
 
-    def _genRecipient(self, recipientType, recipientInt : MeetingRecipientType):
+    def _genRecipient(self, recipientType, recipientInt : MeetingRecipientType) -> Optional[str]:
         """
         Returns the specified recipient field.
         """
@@ -69,35 +69,35 @@ class CalendarBase(MessageBase):
             return value
 
     @property
-    def allAttendeesString(self) -> str:
+    def allAttendeesString(self) -> Optional[str]:
         """
         A list of all attendees, excluding the organizer.
         """
         return self._ensureSetNamed('_allAttendeesString', '8238', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentAuxilaryFlags(self) -> Set[AppointmentAuxilaryFlag]:
+    def appointmentAuxilaryFlags(self) -> Optional[Set[AppointmentAuxilaryFlag]]:
         """
         The auxiliary state of the object.
         """
         return self._ensureSetNamed('_appointmentAuxilaryFlags', '8207', constants.PSETID_APPOINTMENT, overrideClass = AppointmentAuxilaryFlag.fromBits)
 
     @property
-    def appointmentColor(self) -> AppointmentColor:
+    def appointmentColor(self) -> Optional[AppointmentColor]:
         """
         The color to be used when displaying a Calendar object.
         """
         return self._ensureSetNamed('_appointmentColor', '8214', constants.PSETID_APPOINTMENT, overrideClass = AppointmentColor)
 
     @property
-    def appointmentDuration(self) -> int:
+    def appointmentDuration(self) -> Optional[int]:
         """
         The length of the event, in minutes.
         """
         return self._ensureSetNamed('_appointmentDuration', '8213', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentEndWhole(self) -> datetime.datetime:
+    def appointmentEndWhole(self) -> Optional[datetime.datetime]:
         """
         The end date and time of the event in UTC.
         """
@@ -109,10 +109,10 @@ class CalendarBase(MessageBase):
         Indicates that attendees are not allowed to propose a new date and/or
         time for the meeting if True.
         """
-        return self._ensureSetNamed('_appointmentNotAllowPropose', '8259', constants.PSETID_APPOINTMENT)
+        return self._ensureSetNamed('_appointmentNotAllowPropose', '8259', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
-    def appointmentRecur(self) -> RecurrencePattern:
+    def appointmentRecur(self) -> Optional[RecurrencePattern]:
         """
         Specifies the dates and times when a recurring series occurs by using
         one of the recurrence patterns and ranges specified in this section.
@@ -120,7 +120,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_appointmentRecur', '8216', constants.PSETID_APPOINTMENT, overrideClass = RecurrencePattern)
 
     @property
-    def appointmentSequence(self) -> int:
+    def appointmentSequence(self) -> Optional[int]:
         """
         Specified the sequence number of a Meeting object. A meeting object
         begins with the sequence number set to 0 and is incremented each time
@@ -129,14 +129,14 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_appointmentSequence', '8201', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentStartWhole(self) -> datetime.datetime:
+    def appointmentStartWhole(self) -> Optional[datetime.datetime]:
         """
         The start date and time of the event in UTC.
         """
         return self._ensureSetNamed('_appointmentStartWhole', '820D', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentStateFlags(self) -> Set[AppointmentStateFlag]:
+    def appointmentStateFlags(self) -> Optional[Set[AppointmentStateFlag]]:
         """
         The appointment state of the object.
         """
@@ -147,10 +147,10 @@ class CalendarBase(MessageBase):
         """
         Whether the event is an all-day event or not.
         """
-        return self._ensureSetNamed('_appointmentSubType', '8215', constants.PSETID_APPOINTMENT, overrideClass = bool)
+        return self._ensureSetNamed('_appointmentSubType', '8215', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
-    def appointmentTimeZoneDefinitionEndDisplay(self) -> TimeZoneDefinition:
+    def appointmentTimeZoneDefinitionEndDisplay(self) -> Optional[TimeZoneDefinition]:
         """
         Specifies the time zone information for the appointmentEndWhole property
         Used to convert the end date and time to and from UTC.
@@ -158,7 +158,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_appointmentTimeZoneDefinitionEndDisplay', '825F', constants.PSETID_APPOINTMENT, overrideClass = TimeZoneDefinition)
 
     @property
-    def appointmentTimeZoneDefinitionRecur(self) -> TimeZoneDefinition:
+    def appointmentTimeZoneDefinitionRecur(self) -> Optional[TimeZoneDefinition]:
         """
         Specified the time zone information that specifies how to convert the
         meeting date and time on a recurring series to and from UTC.
@@ -166,7 +166,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_appointmentTimeZoneDefinitionRecur', '8260', constants.PSETID_APPOINTMENT, overrideClass = TimeZoneDefinition)
 
     @property
-    def appointmentTimeZoneDefinitionStartDisplay(self) -> TimeZoneDefinition:
+    def appointmentTimeZoneDefinitionStartDisplay(self) -> Optional[TimeZoneDefinition]:
         """
         Specifies the time zone information for the appointmentStartWhole
         property. Used to convert the start date and time to and from UTC.
@@ -174,7 +174,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_appointmentTimeZoneDefinitionStartDisplay', '825E', constants.PSETID_APPOINTMENT, overrideClass = TimeZoneDefinition)
 
     @property
-    def appointmentUnsendableRecipients(self) -> bytes:
+    def appointmentUnsendableRecipients(self) -> Optional[bytes]:
         """
         A list of unsendable attendees.
 
@@ -185,28 +185,28 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_appointmentUnsendableRecipients', '825D', constants.PSETID_APPOINTMENT)
 
     @property
-    def bcc(self):
+    def bcc(self) -> Optional[str]:
         """
         Returns the bcc field, if it exists.
         """
         return self._genRecipient('bcc', MeetingRecipientType.SENDABLE_RESOURCE_OBJECT)
 
     @property
-    def birthdayContactAttributionDisplayName(self) -> str:
+    def birthdayContactAttributionDisplayName(self) -> Optional[str]:
         """
         Indicated the name of the contact associated with the birthday event.
         """
         return self._ensureSetNamed('_birthdayContactAttributionDisplayName', 'BirthdayContactAttributionDisplayName', constants.PSETID_ADDRESS)
 
     @property
-    def birthdayContactEntryID(self) -> EntryID:
+    def birthdayContactEntryID(self) -> Optional[EntryID]:
         """
         Indicates the EntryID of the contact associated with the birthday event.
         """
         return self._ensureSetNamed('_birthdayContactEntryID', 'BirthdayContactEntryId', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def birthdayContactPersonGuid(self) -> bytes:
+    def birthdayContactPersonGuid(self) -> Optional[bytes]:
         """
         Indicates the person ID's GUID of the contact associated with the
         birthday event.
@@ -214,7 +214,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_birthdayContactPersonGuid', 'BirthdayContactPersonGuid', constants.PSETID_ADDRESS)
 
     @property
-    def busyStatus(self) -> BusyStatus:
+    def busyStatus(self) -> Optional[BusyStatus]:
         """
         Specified the availability of a user for the event described by the
         object.
@@ -222,21 +222,21 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_busyStatus', '8205', constants.PSETID_APPOINTMENT, overrideClass = BusyStatus)
 
     @property
-    def cc(self):
+    def cc(self) -> Optional[str]:
         """
         Returns the cc field, if it exists.
         """
         return self._genRecipient('cc', MeetingRecipientType.SENDABLE_OPTIONAL_ATTENDEE)
 
     @property
-    def ccAttendeesString(self) -> str:
+    def ccAttendeesString(self) -> Optional[str]:
         """
         A list of all the sendable attendees, who are also optional attendees.
         """
         return self._ensureSetNamed('_ccAttendeesString', '823C', constants.PSETID_APPOINTMENT)
 
     @property
-    def cleanGlobalObjectID(self) -> GlobalObjectID:
+    def cleanGlobalObjectID(self) -> Optional[GlobalObjectID]:
         """
         The value of the globalObjectID property for an object that represents
         an Exception object to a recurring series, where the year, month, and
@@ -245,7 +245,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_cleanGlobalObjectID', '0023', constants.PSETID_MEETING, overrideClass = GlobalObjectID)
 
     @property
-    def clipEnd(self) -> datetime.datetime:
+    def clipEnd(self) -> Optional[datetime.datetime]:
         """
         For single-instance Calendar objects, the end date and time of the
         event in UTC. For a recurring series, midnight in the user's machine
@@ -258,7 +258,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_clipEnd', '8236', constants.PSETID_APPOINTMENT)
 
     @property
-    def clipStart(self) -> datetime.datetime:
+    def clipStart(self) -> Optional[datetime.datetime]:
         """
         For single-instance Calendar objects, the start date and time of the
         event in UTC. For a recurring series, midnight in the user's machine
@@ -269,14 +269,14 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_clipStart', '8235', constants.PSETID_APPOINTMENT)
 
     @property
-    def commonEnd(self) -> datetime.datetime:
+    def commonEnd(self) -> Optional[datetime.datetime]:
         """
         The end date and time of an event. MUST be equal to appointmentEndWhole.
         """
         return self._ensureSetNamed('_commonEnd', '8517', constants.PSETID_COMMON)
 
     @property
-    def commonStart(self) -> datetime.datetime:
+    def commonStart(self) -> Optional[datetime.datetime]:
         """
         The start date and time of an event. MUST be equal to
         appointmentStartWhole.
@@ -284,21 +284,21 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_commonStart', '8516', constants.PSETID_COMMON)
 
     @property
-    def endDate(self) -> datetime.datetime:
+    def endDate(self) -> Optional[datetime.datetime]:
         """
         The end date of the appointment.
         """
         return self._ensureSetProperty('_endDate', '00610040')
 
     @property
-    def globalObjectID(self) -> GlobalObjectID:
+    def globalObjectID(self) -> Optional[GlobalObjectID]:
         """
         The unique identifier or the Calendar object.
         """
         return self._ensureSetNamed('_globalObjectID', '0003', constants.PSETID_MEETING, overrideClass = GlobalObjectID)
 
     @property
-    def iconIndex(self) -> Union[IconIndex, int]:
+    def iconIndex(self) -> Optional[Union[IconIndex, int]]:
         """
         The icon to use for the object.
         """
@@ -310,7 +310,7 @@ class CalendarBase(MessageBase):
         Indicates whether the contact associated with the birthday event is
         writable.
         """
-        return self._ensureSetNamed('_isBirthdayContactWritable', 'IsBirthdayContactWritable', constants.PSETID_ADDRESS)
+        return self._ensureSetNamed('_isBirthdayContactWritable', 'IsBirthdayContactWritable', constants.PSETID_ADDRESS, overrideClass = bool, preserveNone = False)
 
     @property
     def isException(self) -> bool:
@@ -318,24 +318,24 @@ class CalendarBase(MessageBase):
         Whether the object represents an exception. False indicates that the
         object represents a recurring series or a single-instance object.
         """
-        return self._ensureSetNamed('_isException', '000A', constants.PSETID_MEETING, overrideClass = bool)
+        return self._ensureSetNamed('_isException', '000A', constants.PSETID_MEETING, overrideClass = bool, preserveNone = False)
 
     @property
     def isRecurring(self) -> bool:
         """
         Whether the object is associated with a recurring series.
         """
-        return self._ensureSetNamed('_isRecurring', '0005', constants.PSETID_MEETING, overrideClass = bool)
+        return self._ensureSetNamed('_isRecurring', '0005', constants.PSETID_MEETING, overrideClass = bool, preserveNone = False)
 
     @property
-    def keywords(self) -> List[str]:
+    def keywords(self) -> Optional[List[str]]:
         """
         The color to be used when displaying a Calendar object.
         """
         return self._ensureSet('_keywords', 'Keywords')
 
     @property
-    def linkedTaskItems(self) -> Tuple[EntryID]:
+    def linkedTaskItems(self) -> Optional[Tuple[EntryID]]:
         """
         A list of PidTagEntryId properties of Task objects related to the
         Calendar object that are set by a client.
@@ -343,7 +343,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_linkedTaskItems', '820C', constants.PSETID_APPOINTMENT, overrideClass = lambda x : tuple(EntryID.autoCreate(y) for y in x))
 
     @property
-    def location(self) -> str:
+    def location(self) -> Optional[str]:
         """
         Returns the location of the meeting.
         """
@@ -354,10 +354,10 @@ class CalendarBase(MessageBase):
         """
         Whether to allow the meeting to be forwarded. True disallows forwarding.
         """
-        return self._ensureSetNamed('_meetingDoNotForward', 'DoNotForward', constants.PS_PUBLIC_STRINGS)
+        return self._ensureSetNamed('_meetingDoNotForward', 'DoNotForward', constants.PS_PUBLIC_STRINGS, overrideClass = bool, preserveNone = False)
 
     @property
-    def meetingWorkspaceUrl(self) -> str:
+    def meetingWorkspaceUrl(self) -> Optional[str]:
         """
         The URL of the Meeting Workspace, as specified in [MS-MEETS], that is
         associated with a Calendar object.
@@ -365,63 +365,63 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_meetingWorkspaceUrl', '8209', constants.PSETID_APPOINTMENT)
 
     @property
-    def nonSendableBcc(self) -> str:
+    def nonSendableBcc(self) -> Optional[str]:
         """
         A list of all unsendable attendees who are also resource objects.
         """
         return self._ensureSetNamed('_nonSendableBcc', '8538', constants.PSETID_COMMON)
 
     @property
-    def nonSendableCc(self) -> str:
+    def nonSendableCc(self) -> Optional[str]:
         """
         A list of all unsendable attendees who are also optional attendees.
         """
         return self._ensureSetNamed('_nonSendableCc', '8537', constants.PSETID_COMMON)
 
     @property
-    def nonSendableTo(self) -> str:
+    def nonSendableTo(self) -> Optional[str]:
         """
         A list of all unsendable attendees who are also required attendees.
         """
         return self._ensureSetNamed('_nonSendableTo', '8536', constants.PSETID_COMMON)
 
     @property
-    def nonSendBccTrackStatus(self) -> List[ResponseStatus]:
+    def nonSendBccTrackStatus(self) -> Optional[List[ResponseStatus]]:
         """
         A ResponseStatus for each of the attendees in nonSendableBcc.
         """
         return self._ensureSetNamed('_nonSendBccTrackStatus', '8545', constants.PSETID_COMMON, overrideClass = (lambda x : (ResponseStatus(y) for y in x)))
 
     @property
-    def nonSendCcTrackStatus(self) -> List[ResponseStatus]:
+    def nonSendCcTrackStatus(self) -> Optional[List[ResponseStatus]]:
         """
         A ResponseStatus for each of the attendees in nonSendableCc.
         """
         return self._ensureSetNamed('_nonSendCcTrackStatus', '8544', constants.PSETID_COMMON, overrideClass = (lambda x : (ResponseStatus(y) for y in x)))
 
     @property
-    def nonSendToTrackStatus(self) -> List[ResponseStatus]:
+    def nonSendToTrackStatus(self) -> Optional[List[ResponseStatus]]:
         """
         A ResponseStatus for each of the attendees in nonSendableTo.
         """
         return self._ensureSetNamed('_nonSendToTrackStatus', '8543', constants.PSETID_COMMON, overrideClass = (lambda x : (ResponseStatus(y) for y in x)))
 
     @property
-    def optionalAttendees(self) -> str:
+    def optionalAttendees(self) -> Optional[str]:
         """
         Returns the optional attendees of the meeting.
         """
         return self._ensureSetNamed('_optionalAttendees', '0007', constants.PSETID_MEETING)
 
     @property
-    def organizer(self) -> str:
+    def organizer(self) -> Optional[str]:
         """
         The meeting organizer.
         """
         return self._ensureSet('_organizer', '__substg1.0_0042')
 
     @property
-    def ownerAppointmentID(self) -> int:
+    def ownerAppointmentID(self) -> Optional[int]:
         """
         A quasi-unique value amond all Calendar objects in a user's mailbox.
         Assists a client or server in finding a Calendar object but is not
@@ -430,7 +430,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetProperty('_ownerAppointmentID', '00620003')
 
     @property
-    def ownerCriticalChange(self) -> datetime.datetime:
+    def ownerCriticalChange(self) -> Optional[datetime.datetime]:
         """
         The date and time at which a Meeting Request object was sent by the
         organizer, in UTC.
@@ -438,7 +438,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_ownerCriticalChange', '001A', constants.PSETID_MEETING)
 
     @property
-    def recurrencePattern(self) -> str:
+    def recurrencePattern(self) -> Optional[str]:
         """
         A description of the recurrence specified by the appointmentRecur
         property.
@@ -450,24 +450,24 @@ class CalendarBase(MessageBase):
         """
         Specifies whether the object represents a recurring series.
         """
-        return self._ensureSetNamed('_recurring', '8223', constants.PSETID_APPOINTMENT, overrideClass = bool)
+        return self._ensureSetNamed('_recurring', '8223', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = True)
 
     @property
     def replyRequested(self) -> bool:
         """
         Whether the organizer requests a reply from attendees.
         """
-        return self._ensureSetProperty('_replyRequested', '0C17000B')
+        return self._ensureSetProperty('_replyRequested', '0C17000B', overrideClass = bool, preserveNone = False)
 
     @property
-    def requiredAttendees(self) -> str:
+    def requiredAttendees(self) -> Optional[str]:
         """
         Returns the required attendees of the meeting.
         """
         return self._ensureSetNamed('_requiredAttendees', '0006', constants.PSETID_MEETING)
 
     @property
-    def resourceAttendees(self) -> str:
+    def resourceAttendees(self) -> Optional[str]:
         """
         Returns the resource attendees of the meeting.
         """
@@ -478,7 +478,7 @@ class CalendarBase(MessageBase):
         """
         Whether to send Meeting Response objects to the organizer.
         """
-        return self._ensureSetProperty('_responseRequested', '0063000B')
+        return self._ensureSetProperty('_responseRequested', '0063000B', overrideClass = bool, preserveNone = False)
 
     @property
     def responseStatus(self) -> ResponseStatus:
@@ -488,14 +488,14 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_responseStatus', '8218', constants.PSETID_APPOINTMENT, overrideClass = lambda x: ResponseStatus(x or 0), preserveNone = False)
 
     @property
-    def startDate(self) -> datetime.datetime:
+    def startDate(self) -> Optional[datetime.datetime]:
         """
         The start date of the appointment.
         """
         return self._ensureSetProperty('_startDate', '00600040')
 
     @property
-    def timeZoneDescription(self) -> str:
+    def timeZoneDescription(self) -> Optional[str]:
         """
         A human-readable description of the time zone that is represented by the
         data in the timeZoneStruct property.
@@ -503,7 +503,7 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_timeZoneDescription', '8234', constants.PSETID_APPOINTMENT)
 
     @property
-    def timeZoneStruct(self) -> TimeZoneStruct:
+    def timeZoneStruct(self) -> Optional[TimeZoneStruct]:
         """
         Set on a recurring series to specify time zone information. Specifies
         how to convert time fields between local time and UTC.
@@ -511,14 +511,14 @@ class CalendarBase(MessageBase):
         return self._ensureSetNamed('_timeZoneStruct', '8233', constants.PSETID_APPOINTMENT, overrideClass = TimeZoneStruct)
 
     @property
-    def to(self):
+    def to(self) -> Optional[str]:
         """
         Returns the to field, if it exists.
         """
         return self._genRecipient('to', MeetingRecipientType.SENDABLE_REQUIRED_ATTENDEE)
 
     @property
-    def toAttendeesString(self) -> str:
+    def toAttendeesString(self) -> Optional[str]:
         """
         A list of all the sendable attendees, who are also required attendees.
         """

--- a/extract_msg/contact.py
+++ b/extract_msg/contact.py
@@ -1,6 +1,6 @@
 import datetime
 
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from . import constants
 from .enums import ContactLinkState, ElectronicAddressProperties, Gender, PostalAddressID
@@ -37,14 +37,14 @@ class Contact(MessageBase):
         self.namedProperties
 
     @property
-    def account(self) -> str:
+    def account(self) -> Optional[str]:
         """
         The account name of the contact.
         """
         return self._ensureSet('_account', '__substg1.0_3A00')
 
     @property
-    def addressBookProviderArrayType(self) -> Set[ElectronicAddressProperties]:
+    def addressBookProviderArrayType(self) -> Optional[Set[ElectronicAddressProperties]]:
         """
         A set of which Electronic Address properties are set on the contact.
 
@@ -54,21 +54,21 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_addressBookProviderArrayType', '8029', constants.PSETID_ADDRESS, ElectronicAddressProperties.fromBits)
 
     @property
-    def addressBookProviderEmailList(self) -> Set[ElectronicAddressProperties]:
+    def addressBookProviderEmailList(self) -> Optional[Set[ElectronicAddressProperties]]:
         """
         A set of which Electronic Address properties are set on the contact.
         """
         return self._ensureSetNamed('_addressBookProviderEmailList', '8028', constants.PSETID_ADDRESS, overrideClass = lambda x : {ElectronicAddressProperties(y) for y in x})
 
     @property
-    def assistant(self) -> str:
+    def assistant(self) -> Optional[str]:
         """
         The name of the contact's assistant.
         """
         return self._ensureSet('_assistant', '__substg1.0_3A30')
 
     @property
-    def assistantTelephoneNumber(self) -> str:
+    def assistantTelephoneNumber(self) -> Optional[str]:
         """
         Contains the telephone number of the contact's administrative assistant.
         """
@@ -80,24 +80,24 @@ class Contact(MessageBase):
         Whether the client should create a Journal object for each action
         associated with the Contact object.
         """
-        return self._ensureSetNamed('_autoLog', '8025', constants.PSETID_ADDRESS)
+        return self._ensureSetNamed('_autoLog', '8025', constants.PSETID_ADDRESS, overrideClass = bool, preserveNone = False)
 
     @property
-    def billing(self) -> str:
+    def billing(self) -> Optional[str]:
         """
         Billing information for the contact.
         """
         return self._ensureSetNamed('_billing', '8535', constants.PSETID_COMMON)
 
     @property
-    def birthday(self) -> datetime.datetime:
+    def birthday(self) -> Optional[datetime.datetime]:
         """
         The birthday of the contact at 11:59 UTC.
         """
         return self._ensureSetProperty('_birthday', '3A420040')
 
     @property
-    def birthdayEventEntryID(self) -> EntryID:
+    def birthdayEventEntryID(self) -> Optional[EntryID]:
         """
         The EntryID of an optional Appointement object that represents the
         contact's birtday.
@@ -105,7 +105,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_birthdayEventEntryID', '804D', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def birthdayLocal(self) -> datetime.datetime:
+    def birthdayLocal(self) -> Optional[datetime.datetime]:
         """
         The birthday of the contact at 0:00 in the client's local time zone.
         """
@@ -138,7 +138,7 @@ class Contact(MessageBase):
         return im
 
     @property
-    def businessCardCardPicture(self) -> bytes:
+    def businessCardCardPicture(self) -> Optional[bytes]:
         """
         The image to be used on a business card. Must be either a PNG file or a
         JPEG file.
@@ -146,7 +146,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_businessCardCardPicture', '8041', constants.PSETID_ADDRESS)
 
     @property
-    def businessCardDisplayDefinition(self) -> BusinessCardDisplayDefinition:
+    def businessCardDisplayDefinition(self) -> Optional[BusinessCardDisplayDefinition]:
         """
         Specifies the customization details for displaying a contact as a
         business card.
@@ -154,7 +154,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_businessCardDisplayDefinition', '8040', constants.PSETID_ADDRESS, overrideClass = BusinessCardDisplayDefinition)
 
     @property
-    def businessFax(self) -> dict:
+    def businessFax(self) -> Optional[dict]:
         """
         Returns a dict of the data for the business fax. Returns None if no
         fields are set.
@@ -176,14 +176,14 @@ class Contact(MessageBase):
             return self._businessFax
 
     @property
-    def businessFaxAddressType(self) -> str:
+    def businessFaxAddressType(self) -> Optional[str]:
         """
         The type of address for the fax. MUST be set to "FAX" if present.
         """
         return self._ensureSetNamed('_businessFaxAddressType', '80C2', constants.PSETID_ADDRESS)
 
     @property
-    def businessFaxEmailAddress(self) -> str:
+    def businessFaxEmailAddress(self) -> Optional[str]:
         """
         Contains a user-readable display name, followed by the "@" character,
         followed by a fax number.
@@ -191,126 +191,126 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_businessFaxEmailAddress', '80C3', constants.PSETID_ADDRESS)
 
     @property
-    def businessFaxNumber(self) -> str:
+    def businessFaxNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's business fax.
         """
         return self._ensureSet('_businessFaxNumber', '__substg1.0_3A24')
 
     @property
-    def businessFaxOriginalDisplayName(self) -> str:
+    def businessFaxOriginalDisplayName(self) -> Optional[str]:
         """
         The normalized subject for the contact.
         """
         return self._ensureSetNamed('_businessFaxOriginalDisplayName', '80C4', constants.PSETID_ADDRESS)
 
     @property
-    def businessFaxOriginalEntryId(self) -> EntryID:
+    def businessFaxOriginalEntryId(self) -> Optional[EntryID]:
         """
         The one-off EntryID corresponding to this fax address.
         """
         return self._ensureSetNamed('_businessFaxOriginalEntryId', '80C5', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def businessTelephoneNumber(self) -> str:
+    def businessTelephoneNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's business telephone.
         """
         return self._ensureSet('_businessTelephoneNumber', '__substg1.0_3A08')
 
     @property
-    def businessTelephone2Number(self) -> Union[str, List[str]]:
+    def businessTelephone2Number(self) -> Optional[Union[str, List[str]]]:
         """
         Contains the second number or numbers of the contact's business.
         """
         return self._ensureSetTyped('_businessTelephone2Number', '3A1B')
 
     @property
-    def businessHomePage(self) -> str:
+    def businessHomePage(self) -> Optional[str]:
         """
         Contains the url of the homepage of the contact's business.
         """
         return self._ensureSet('_businessHomePage', '__substg1.0_3A51')
 
     @property
-    def callbackTelephoneNumber(self) -> str:
+    def callbackTelephoneNumber(self) -> Optional[str]:
         """
         Contains the contact's callback telephone number.
         """
         return self._ensureSet('_callbackTelephoneNumber', '__substg1.0_3A02')
 
     @property
-    def carTelephoneNumber(self) -> str:
+    def carTelephoneNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's car telephone.
         """
         return self._ensureSet('_carTelephoneNumber', '__substg1.0_3A1E')
 
     @property
-    def childrensNames(self) -> List[str]:
+    def childrensNames(self) -> Optional[List[str]]:
         """
         A list of the named of the contact's children.
         """
         return self._ensureSetTyped('_childrensNames', '3A58')
 
     @property
-    def companyMainTelephoneNumber(self) -> str:
+    def companyMainTelephoneNumber(self) -> Optional[str]:
         """
         Contains the number of the main telephone of the contact's company.
         """
         return self._ensureSet('_companyMainTelephoneNumber', '__substg1.0_3A57')
 
     @property
-    def companyName(self) -> str:
+    def companyName(self) -> Optional[str]:
         """
         The name of the company the contact works at.
         """
         return self._ensureSet('_companyName', '__substg1.0_3A16')
 
     @property
-    def computerNetworkName(self) -> str:
+    def computerNetworkName(self) -> Optional[str]:
         """
         The name of the network to wwhich the contact's computer is connected.
         """
         return self._ensureSet('_computerNetworkName', '__substg1.0_3A49')
 
     @property
-    def contactCharacterSet(self) -> int:
+    def contactCharacterSet(self) -> Optional[int]:
         """
         The character set that is used for this Contact object.
         """
         return self._ensureSetNamed('_contactCharacterSet', '8023', constants.PSETID_ADDRESS)
 
     @property
-    def contactItemData(self) -> List[int]:
+    def contactItemData(self) -> Optional[List[int]]:
         """
         Used to help display the contact information.
         """
         return self._ensureSetNamed('_contactItemData', '8007', constants.PSETID_ADDRESS)
 
     @property
-    def contactLinkedGlobalAddressListEntryID(self) -> EntryID:
+    def contactLinkedGlobalAddressListEntryID(self) -> Optional[EntryID]:
         """
         The EntryID of the GAL object to which the duplicate contact is linked.
         """
         return self._ensureSetNamed('_contactLinkedGlobalAddressListEntryID', '80E2', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def contactLinkGlobalAddressListLinkID(self) -> str:
+    def contactLinkGlobalAddressListLinkID(self) -> Optional[str]:
         """
         The GUID of the GAL contact to which the duplicate contact is linked.
         """
         return self._ensureSetNamed('_contactLinkGlobalAddressListLinkId', '80E8', constants.PSETID_ADDRESS)
 
     @property
-    def contactLinkGlobalAddressListLinkState(self) -> ContactLinkState:
+    def contactLinkGlobalAddressListLinkState(self) -> Optional[ContactLinkState]:
         """
         The state of linking between the GAL contact and the duplicate contact.
         """
         return self._ensureSetNamed('_contactLinkGlobalAddressListLinkState', '80E6', constants.PSETID_ADDRESS, overrideClass = ContactLinkState)
 
     @property
-    def contactLinkLinkRejectHistory(self) -> List[bytes]:
+    def contactLinkLinkRejectHistory(self) -> Optional[List[bytes]]:
         """
         A list of any contacts that were previously rejected for linking with
         the duplicate contact.
@@ -318,7 +318,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_contactLinkLinkRejectHistory', '80E5', constants.PSETID_ADDRESS)
 
     @property
-    def contactLinkSMTPAddressCache(self) -> List[str]:
+    def contactLinkSMTPAddressCache(self) -> Optional[List[str]]:
         """
         A list of the SMTP addresses that are used by the GAL contact that are
         linked to the duplicate contact.
@@ -326,7 +326,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_contactLinkSMTPAddressCache', '80E3', constants.PSETID_ADDRESS)
 
     @property
-    def contactPhoto(self) -> bytes:
+    def contactPhoto(self) -> Optional[bytes]:
         """
         The contact photo, if it exists.
         """
@@ -342,63 +342,63 @@ class Contact(MessageBase):
             return self._contactPhoto
 
     @property
-    def contactUserField1(self) -> str:
+    def contactUserField1(self) -> Optional[str]:
         """
         Used to store custom text for a business card.
         """
         return self._ensureSetNamed('_contactUserField1', '804F', constants.PSETID_ADDRESS)
 
     @property
-    def contactUserField2(self) -> str:
+    def contactUserField2(self) -> Optional[str]:
         """
         Used to store custom text for a business card.
         """
         return self._ensureSetNamed('_contactUserField2', '8050', constants.PSETID_ADDRESS)
 
     @property
-    def contactUserField3(self) -> str:
+    def contactUserField3(self) -> Optional[str]:
         """
         Used to store custom text for a business card.
         """
         return self._ensureSetNamed('_contactUserField3', '8051', constants.PSETID_ADDRESS)
 
     @property
-    def contactUserField4(self) -> str:
+    def contactUserField4(self) -> Optional[str]:
         """
         Used to store custom text for a business card.
         """
         return self._ensureSetNamed('_contactUserField4', '8052', constants.PSETID_ADDRESS)
 
     @property
-    def customerID(self) -> str:
+    def customerID(self) -> Optional[str]:
         """
         The contact's customer ID number.
         """
         return self._ensureSet('_customerID', '__substg1.0_3A4A')
 
     @property
-    def departmentName(self) -> str:
+    def departmentName(self) -> Optional[str]:
         """
         The name of the department the contact works in.
         """
         return self._ensureSet('_departmentName', '__substg1.0_3A18')
 
     @property
-    def displayName(self) -> str:
+    def displayName(self) -> Optional[str]:
         """
         The full name of the contact.
         """
         return self._ensureSet('_displayName', '__substg1.0_3001')
 
     @property
-    def displayNamePrefix(self) -> str:
+    def displayNamePrefix(self) -> Optional[str]:
         """
         The contact's honorific title.
         """
         return self._ensureSet('_displayNamePrefix', '__substg1.0_3A45')
 
     @property
-    def email1(self) -> dict:
+    def email1(self) -> Optional[dict]:
         """
         Returns a dict of the data for email 1. Returns None if no fields are
         set.
@@ -420,28 +420,28 @@ class Contact(MessageBase):
             return self._email1
 
     @property
-    def email1AddressType(self) -> str:
+    def email1AddressType(self) -> Optional[str]:
         """
         The address type of the first email address.
         """
         return self._ensureSetNamed('_email1AddressType', '8082', constants.PSETID_ADDRESS)
 
     @property
-    def email1DisplayName(self) -> str:
+    def email1DisplayName(self) -> Optional[str]:
         """
         The user-readable display name of the first email address.
         """
         return self._ensureSetNamed('_email1DisplayName', '8080', constants.PSETID_ADDRESS)
 
     @property
-    def email1EmailAddress(self) -> str:
+    def email1EmailAddress(self) -> Optional[str]:
         """
         The first email address.
         """
         return self._ensureSetNamed('_email1EmailAddress', '8083', constants.PSETID_ADDRESS)
 
     @property
-    def email1OriginalDisplayName(self) -> str:
+    def email1OriginalDisplayName(self) -> Optional[str]:
         """
         The first SMTP email address that corresponds to the first email address
         for the contact.
@@ -449,14 +449,14 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_email1OriginalDisplayName', '8084', constants.PSETID_ADDRESS)
 
     @property
-    def email1OriginalEntryId(self) -> EntryID:
+    def email1OriginalEntryId(self) -> Optional[EntryID]:
         """
         The EntryID of the object correspinding to this electronic address.
         """
         return self._ensureSetNamed('_email1OriginalEntryId', '8085', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def email2(self) -> dict:
+    def email2(self) -> Optional[dict]:
         """
         Returns a dict of the data for email 2. Returns None if no fields are
         set.
@@ -475,28 +475,28 @@ class Contact(MessageBase):
             return self._email2
 
     @property
-    def email2AddressType(self) -> str:
+    def email2AddressType(self) -> Optional[str]:
         """
         The address type of the second email address.
         """
         return self._ensureSetNamed('_email2AddressType', '8092', constants.PSETID_ADDRESS)
 
     @property
-    def email2DisplayName(self) -> str:
+    def email2DisplayName(self) -> Optional[str]:
         """
         The user-readable display name of the second email address.
         """
         return self._ensureSetNamed('_email2DisplayName', '8090', constants.PSETID_ADDRESS)
 
     @property
-    def email2EmailAddress(self) -> str:
+    def email2EmailAddress(self) -> Optional[str]:
         """
         The second email address.
         """
         return self._ensureSetNamed('_email2EmailAddress', '8093', constants.PSETID_ADDRESS)
 
     @property
-    def email2OriginalDisplayName(self) -> str:
+    def email2OriginalDisplayName(self) -> Optional[str]:
         """
         The second SMTP email address that corresponds to the second email address
         for the contact.
@@ -504,14 +504,14 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_email2OriginalDisplayName', '8094', constants.PSETID_ADDRESS)
 
     @property
-    def email2OriginalEntryId(self) -> EntryID:
+    def email2OriginalEntryId(self) -> Optional[EntryID]:
         """
         The EntryID of the object correspinding to this electronic address.
         """
         return self._ensureSetNamed('_email2OriginalEntryId', '8095', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def email3(self) -> dict:
+    def email3(self) -> Optional[dict]:
         """
         Returns a dict of the data for email 3. Returns None if no fields are
         set.
@@ -530,28 +530,28 @@ class Contact(MessageBase):
             return self._email3
 
     @property
-    def email3AddressType(self) -> str:
+    def email3AddressType(self) -> Optional[str]:
         """
         The address type of the third email address.
         """
         return self._ensureSetNamed('_email3AddressType', '80A2', constants.PSETID_ADDRESS)
 
     @property
-    def email3DisplayName(self) -> str:
+    def email3DisplayName(self) -> Optional[str]:
         """
         The user-readable display name of the third email address.
         """
         return self._ensureSetNamed('_email3DisplayName', '80A0', constants.PSETID_ADDRESS)
 
     @property
-    def email3EmailAddress(self) -> str:
+    def email3EmailAddress(self) -> Optional[str]:
         """
         The third email address.
         """
         return self._ensureSetNamed('_email3EmailAddress', '80A3', constants.PSETID_ADDRESS)
 
     @property
-    def email3OriginalDisplayName(self) -> str:
+    def email3OriginalDisplayName(self) -> Optional[str]:
         """
         The third SMTP email address that corresponds to the third email address
         for the contact.
@@ -559,14 +559,14 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_email3OriginalDisplayName', '80A4', constants.PSETID_ADDRESS)
 
     @property
-    def email3OriginalEntryId(self) -> EntryID:
+    def email3OriginalEntryId(self) -> Optional[EntryID]:
         """
         The EntryID of the object correspinding to this electronic address.
         """
         return self._ensureSetNamed('_email3OriginalEntryId', '80A5', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def emails(self) -> tuple:
+    def emails(self) -> Tuple[Union[Dict, None], Union[Dict, None], Union[Dict, None]]:
         """
         Returns a tuple of all the email dicts. Value for an email will be None
         if no fields were set.
@@ -578,7 +578,7 @@ class Contact(MessageBase):
             return self._emails
 
     @property
-    def faxNumbers(self) -> dict:
+    def faxNumbers(self) -> Optional[dict]:
         """
         Returns a dictionary of the fax numbers. Entry will be None if no fields
         were set.
@@ -595,7 +595,7 @@ class Contact(MessageBase):
             }
 
     @property
-    def fileUnder(self) -> str:
+    def fileUnder(self) -> Optional[str]:
         """
         The name under which to file a contact when displaying a list of
         contacts.
@@ -603,7 +603,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_fileUnder', '8005', constants.PSETID_ADDRESS)
 
     @property
-    def fileUnderID(self) -> int:
+    def fileUnderID(self) -> Optional[int]:
         """
         The format to use for fileUnder. See PidLidFileUnderId in [MS-OXOCNTC]
         for details.
@@ -611,7 +611,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_fileUnderID', '8006', constants.PSETID_ADDRESS)
 
     @property
-    def freeBusyLocation(self) -> str:
+    def freeBusyLocation(self) -> Optional[str]:
         """
         A URL path from which a client can retrieve free/busy status information
         for the contact as an iCalendat file.
@@ -619,21 +619,21 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_freeBusyLocation', '80D8', constants.PSETID_ADDRESS)
 
     @property
-    def ftpSite(self) -> str:
+    def ftpSite(self) -> Optional[str]:
         """
         The contact's File Transfer Protocol url.
         """
         return self._ensureSet('_ftpSite', '__substg1.0_3A4C')
 
     @property
-    def gender(self) -> Gender:
+    def gender(self) -> Optional[Gender]:
         """
         The gender of the contact.
         """
         return self._ensureSet('_gender', '__substg1.0_3A4D', overrideClass = Gender)
 
     @property
-    def generation(self) -> str:
+    def generation(self) -> Optional[str]:
         """
         A generational abbreviation that follows the full
         name of the contact.
@@ -641,14 +641,14 @@ class Contact(MessageBase):
         return self._ensureSet('_generation', '__substg1.0_3A05')
 
     @property
-    def givenName(self) -> str:
+    def givenName(self) -> Optional[str]:
         """
         The first name of the contact.
         """
         return self._ensureSet('_givenName', '__substg1.0_3A06')
 
     @property
-    def governmentIDNumber(self) -> str:
+    def governmentIDNumber(self) -> Optional[str]:
         """
         The contact's government ID number.
         """
@@ -754,70 +754,70 @@ class Contact(MessageBase):
         }
 
     @property
-    def hobbies(self) -> str:
+    def hobbies(self) -> Optional[str]:
         """
         The hobies of the contact.
         """
         return self._ensureSet('_hobbies', '__substg1.0_3A43')
 
     @property
-    def homeAddress(self) -> str:
+    def homeAddress(self) -> Optional[str]:
         """
         The complete home address of the contact.
         """
         return self._ensureSetNamed('_homeAddress', '801A', constants.PSETID_ADDRESS)
 
     @property
-    def homeAddressCountry(self) -> str:
+    def homeAddressCountry(self) -> Optional[str]:
         """
         The country portion of the contact's home address.
         """
         return self._ensureSet('_homeAddressCountry', '__substg1.0_3A5A')
 
     @property
-    def homeAddressCountryCode(self) -> str:
+    def homeAddressCountryCode(self) -> Optional[str]:
         """
         The country code portion of the contact's home address.
         """
         return self._ensureSetNamed('_homeAddressCountryCode', '80DA', constants.PSETID_ADDRESS)
 
     @property
-    def homeAddressLocality(self) -> str:
+    def homeAddressLocality(self) -> Optional[str]:
         """
         The locality or city portion of the contact's home address.
         """
         return self._ensureSet('_homeAddressLocality', '__substg1.0_3A59')
 
     @property
-    def homeAddressPostalCode(self) -> str:
+    def homeAddressPostalCode(self) -> Optional[str]:
         """
         The postal code portion of the contact's home address.
         """
         return self._ensureSet('_homeAddressPostalCode', '__substg1.0_3A5B')
 
     @property
-    def homeAddressPostOfficeBox(self) -> str:
+    def homeAddressPostOfficeBox(self) -> Optional[str]:
         """
         The number or identifier of the contact's home post office box.
         """
         return self._ensureSet('_homeAddressPostOfficeBox', '__substg1.0_3A5E')
 
     @property
-    def homeAddressStateOrProvince(self) -> str:
+    def homeAddressStateOrProvince(self) -> Optional[str]:
         """
         The state or province portion of the contact's home address.
         """
         return self._ensureSet('_homeAddressStateOrProvince', '__substg1.0_3A5C')
 
     @property
-    def homeAddressStreet(self) -> str:
+    def homeAddressStreet(self) -> Optional[str]:
         """
         The street portion of the contact's home address.
         """
         return self._ensureSet('_homeAddressStreet', '__substg1.0_3A5D')
 
     @property
-    def homeFax(self) -> dict:
+    def homeFax(self) -> Optional[dict]:
         """
         Returns a dict of the data for the home fax. Returns None if no fields
         are set.
@@ -839,14 +839,14 @@ class Contact(MessageBase):
             return self._homeFax
 
     @property
-    def homeFaxAddressType(self) -> str:
+    def homeFaxAddressType(self) -> Optional[str]:
         """
         The type of address for the fax. MUST be set to "FAX" if present.
         """
         return self._ensureSetNamed('_homeFaxAddressType', '80D2', constants.PSETID_ADDRESS)
 
     @property
-    def homeFaxEmailAddress(self) -> str:
+    def homeFaxEmailAddress(self) -> Optional[str]:
         """
         Contains a user-readable display name, followed by the "@" character,
         followed by a fax number.
@@ -854,49 +854,49 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_homeFaxEmailAddress', '80D3', constants.PSETID_ADDRESS)
 
     @property
-    def homeFaxNumber(self) -> str:
+    def homeFaxNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's home fax.
         """
         return self._ensureSet('_homeFaxNumber', '__substg1.0_3A25')
 
     @property
-    def homeFaxOriginalDisplayName(self) -> str:
+    def homeFaxOriginalDisplayName(self) -> Optional[str]:
         """
         The normalized subject for the contact.
         """
         return self._ensureSetNamed('_homeFaxOriginalDisplayName', '80D4', constants.PSETID_ADDRESS)
 
     @property
-    def homeFaxOriginalEntryId(self) -> EntryID:
+    def homeFaxOriginalEntryId(self) -> Optional[EntryID]:
         """
         The one-off EntryID corresponding to this fax address.
         """
         return self._ensureSetNamed('_homeFaxOriginalEntryId', '80D5', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def homeTelephoneNumber(self) -> str:
+    def homeTelephoneNumber(self) -> Optional[str]:
         """
         The number of the contact's home telephone.
         """
         return self._ensureSet('_homeTelephoneNumber', '__substg1.0_3A09')
 
     @property
-    def homeTelephone2Number(self) -> Union[str, List[str]]:
+    def homeTelephone2Number(self) -> Optional[Union[str, List[str]]]:
         """
         The number(s) of the contact's second home telephone.
         """
         return self._ensureSetTyped('_homeTelephone2Number', '3A2F')
 
     @property
-    def initials(self) -> str:
+    def initials(self) -> Optional[str]:
         """
         The initials of the contact.
         """
         return self._ensureSet('_initials', '__substg1.0_3A0A')
 
     @property
-    def instantMessagingAddress(self) -> str:
+    def instantMessagingAddress(self) -> Optional[str]:
         """
         The instant messaging address of the contact.
         """
@@ -907,10 +907,10 @@ class Contact(MessageBase):
         """
         Whether the contact is linked to other contacts.
         """
-        return self._ensureSetNamed('_isContactLinked', '80E0', constants.PSETID_ADDRESS)
+        return self._ensureSetNamed('_isContactLinked', '80E0', constants.PSETID_ADDRESS, overrideClass = bool, preserveNone = False)
 
     @property
-    def isdnNumber(self) -> str:
+    def isdnNumber(self) -> Optional[str]:
         """
         The Integrated Services Digital Network (ISDN) telephone number of the
         contact.
@@ -918,28 +918,28 @@ class Contact(MessageBase):
         return self._ensureSet('_isdnNumber', '__substg1.0_3A2D')
 
     @property
-    def jobTitle(self) -> str:
+    def jobTitle(self) -> Optional[str]:
         """
         The job title of the contact.
         """
         return self._ensureSet('_jobTitle', '__substg1.0_3A17')
 
     @property
-    def language(self) -> str:
+    def language(self) -> Optional[str]:
         """
         The language that the contact uses.
         """
         return self._ensureSet('_language', '__substg1.0_3A0C')
 
     @property
-    def lastModifiedBy(self) -> str:
+    def lastModifiedBy(self) -> Optional[str]:
         """
         The name of the last user to modify the contact file.
         """
         return self._ensureSet('_lastModifiedBy', '__substg1.0_3FFA')
 
     @property
-    def location(self) -> str:
+    def location(self) -> Optional[str]:
         """
         The location of the contact. For example, this could be the building or
         office number of the contact.
@@ -947,98 +947,98 @@ class Contact(MessageBase):
         return self._ensureSet('_location', '__substg1.0_3A0D')
 
     @property
-    def mailAddress(self) -> str:
+    def mailAddress(self) -> Optional[str]:
         """
         The complete mail address of the contact.
         """
         return self._ensureSet('_mailAddress', '__substg1.0_3A15')
 
     @property
-    def mailAddressCountry(self) -> str:
+    def mailAddressCountry(self) -> Optional[str]:
         """
         The country portion of the contact's mail address.
         """
         return self._ensureSet('_mailAddressCountry', '__substg1.0_3A26')
 
     @property
-    def mailAddressCountryCode(self) -> str:
+    def mailAddressCountryCode(self) -> Optional[str]:
         """
         The country code portion of the contact's mail address.
         """
         return self._ensureSetNamed('_mailAddressCountryCode', '80DD', constants.PSETID_ADDRESS)
 
     @property
-    def mailAddressLocality(self) -> str:
+    def mailAddressLocality(self) -> Optional[str]:
         """
         The locality or city portion of the contact's mail address.
         """
         return self._ensureSet('_mailAddressLocality', '__substg1.0_3A27')
 
     @property
-    def mailAddressPostalCode(self) -> str:
+    def mailAddressPostalCode(self) -> Optional[str]:
         """
         The postal code portion of the contact's mail address.
         """
         return self._ensureSet('_mailAddressPostalCode', '__substg1.0_3A2A')
 
     @property
-    def mailAddressPostOfficeBox(self) -> str:
+    def mailAddressPostOfficeBox(self) -> Optional[str]:
         """
         The number or identifier of the contact's mail post office box.
         """
         return self._ensureSet('_mailAddressPostOfficeBox', '__substg1.0_3A2B')
 
     @property
-    def mailAddressStateOrProvince(self) -> str:
+    def mailAddressStateOrProvince(self) -> Optional[str]:
         """
         The state or province portion of the contact's mail address.
         """
         return self._ensureSet('_mailAddressStateOrProvince', '__substg1.0_3A28')
 
     @property
-    def mailAddressStreet(self) -> str:
+    def mailAddressStreet(self) -> Optional[str]:
         """
         The street portion of the contact's mail address.
         """
         return self._ensureSet('_mailAddressStreet', '__substg1.0_3A29')
 
     @property
-    def managerName(self) -> str:
+    def managerName(self) -> Optional[str]:
         """
         The name of the contact's manager.
         """
         return self._ensureSet('_managerName', '__substg1.0_3A4E')
 
     @property
-    def middleName(self) -> str:
+    def middleName(self) -> Optional[str]:
         """
         The middle name(s) of the contact.
         """
         return self._ensureSet('_middleNames', '__substg1.0_3A44')
 
     @property
-    def mobileTelephoneNumber(self) -> str:
+    def mobileTelephoneNumber(self) -> Optional[str]:
         """
         The mobile telephone number of the contact.
         """
         return self._ensureSet('_mobileTelephoneNumber', '__substg1.0_3A1C')
 
     @property
-    def nickname(self) -> str:
+    def nickname(self) -> Optional[str]:
         """
         The nickname of the contanct.
         """
         return self._ensureSet('_nickname', '__substg1.0_3A4F')
 
     @property
-    def officeLocation(self) -> str:
+    def officeLocation(self) -> Optional[str]:
         """
         The location of the office that the contact works in.
         """
         return self._ensureSet('_officeLocation', '__substg1.0_3A19')
 
     @property
-    def organizationalIDNumber(self) -> str:
+    def organizationalIDNumber(self) -> Optional[str]:
         """
         The organizational ID number for the contact, such as an employee ID
         number.
@@ -1051,101 +1051,101 @@ class Contact(MessageBase):
         Whether contact synchronization with an external source (such as a
         social networking site) is handled by the server.
         """
-        return self._ensureSetProperty('_oscSyncEnabled', '7C24000B')
+        return self._ensureSetProperty('_oscSyncEnabled', '7C24000B', overrideClass = bool, preserveNone = False)
 
     @property
-    def otherAddress(self) -> str:
+    def otherAddress(self) -> Optional[str]:
         """
         The complete other address of the contact.
         """
         return self._ensureSetNamed('_otherAddress', '801C', constants.PSETID_ADDRESS)
 
     @property
-    def otherAddressCountry(self) -> str:
+    def otherAddressCountry(self) -> Optional[str]:
         """
         The country portion of the contact's other address.
         """
         return self._ensureSet('_otherAddressCountry', '__substg1.0_3A60')
 
     @property
-    def otherAddressCountryCode(self) -> str:
+    def otherAddressCountryCode(self) -> Optional[str]:
         """
         The country code portion of the contact's other address.
         """
         return self._ensureSetNamed('_otherAddressCountryCode', '80DC', constants.PSETID_ADDRESS)
 
     @property
-    def otherAddressLocality(self) -> str:
+    def otherAddressLocality(self) -> Optional[str]:
         """
         The locality or city portion of the contact's other address.
         """
         return self._ensureSet('_otherAddressLocality', '__substg1.0_3A5F')
 
     @property
-    def otherAddressPostalCode(self) -> str:
+    def otherAddressPostalCode(self) -> Optional[str]:
         """
         The postal code portion of the contact's other address.
         """
         return self._ensureSet('_otherAddressPostalCode', '__substg1.0_3A61')
 
     @property
-    def otherAddressPostOfficeBox(self) -> str:
+    def otherAddressPostOfficeBox(self) -> Optional[str]:
         """
         The number or identifier of the contact's other post office box.
         """
         return self._ensureSet('_otherAddressPostOfficeBox', '__substg1.0_3A64')
 
     @property
-    def otherAddressStateOrProvince(self) -> str:
+    def otherAddressStateOrProvince(self) -> Optional[str]:
         """
         The state or province portion of the contact's other address.
         """
         return self._ensureSet('_otherAddressStateOrProvince', '__substg1.0_3A62')
 
     @property
-    def otherAddressStreet(self) -> str:
+    def otherAddressStreet(self) -> Optional[str]:
         """
         The street portion of the contact's other address.
         """
         return self._ensureSet('_otherAddressStreet', '__substg1.0_3A63')
 
     @property
-    def otherTelephoneNumber(self) -> str:
+    def otherTelephoneNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's other telephone.
         """
         return self._ensureSet('_otherTelephoneNumber', '__substg1.0_3A1F')
 
     @property
-    def pagerTelephoneNumber(self) -> str:
+    def pagerTelephoneNumber(self) -> Optional[str]:
         """
         The contact's pager telephone number.
         """
         return self._ensureSet('_pagerTelephoneNumber', '__substg1.0_3A21')
 
     @property
-    def personalHomePage(self) -> str:
+    def personalHomePage(self) -> Optional[str]:
         """
         The contact's personal web page UL.
         """
         return self._ensureSet('_personalHomePage', '__substg1.0_3A50')
 
     @property
-    def phoneticCompanyName(self) -> str:
+    def phoneticCompanyName(self) -> Optional[str]:
         """
         The phonetic pronunciation of the contact's company name.
         """
         return self._ensureSetNamed('_phoneticCompanyName', '802E', constants.PSETID_ADDRESS)
 
     @property
-    def phoneticGivenName(self) -> str:
+    def phoneticGivenName(self) -> Optional[str]:
         """
         The phonetic pronunciation of the contact's given name.
         """
         return self._ensureSetNamed('_phoneticGivenName', '802C', constants.PSETID_ADDRESS)
 
     @property
-    def phoneticSurname(self) -> str:
+    def phoneticSurname(self) -> Optional[str]:
         """
         The phonetic pronunciation of the given name of the contact.
         """
@@ -1160,7 +1160,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_postalAddressID', '8022', constants.PSETID_ADDRESS, overrideClass = lambda x : PostalAddressID(x or 0), preserveNone = False)
 
     @property
-    def primaryFax(self) -> dict:
+    def primaryFax(self) -> Optional[dict]:
         """
         Returns a dict of the data for the primary fax. Returns None if no
         fields are set.
@@ -1182,14 +1182,14 @@ class Contact(MessageBase):
             return self._primaryFax
 
     @property
-    def primaryFaxAddressType(self) -> str:
+    def primaryFaxAddressType(self) -> Optional[str]:
         """
         The type of address for the fax. MUST be set to "FAX" if present.
         """
         return self._ensureSetNamed('_primaryFaxAddressType', '80B2', constants.PSETID_ADDRESS)
 
     @property
-    def primaryFaxEmailAddress(self) -> str:
+    def primaryFaxEmailAddress(self) -> Optional[str]:
         """
         Contains a user-readable display name, followed by the "@" character,
         followed by a fax number.
@@ -1197,49 +1197,49 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_primaryFaxEmailAddress', '80B3', constants.PSETID_ADDRESS)
 
     @property
-    def primaryFaxNumber(self) -> str:
+    def primaryFaxNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's primary fax.
         """
         return self._ensureSet('_primaryFaxNumber', '__substg1.0_3A23')
 
     @property
-    def primaryFaxOriginalDisplayName(self) -> str:
+    def primaryFaxOriginalDisplayName(self) -> Optional[str]:
         """
         The normalized subject for the contact.
         """
         return self._ensureSetNamed('_primaryFaxOriginalDisplayName', '80B4', constants.PSETID_ADDRESS)
 
     @property
-    def primaryFaxOriginalEntryId(self) -> EntryID:
+    def primaryFaxOriginalEntryId(self) -> Optional[EntryID]:
         """
         The one-off EntryID corresponding to this fax address.
         """
         return self._ensureSetNamed('_primaryFaxOriginalEntryId', '80B5', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def primaryTelephoneNumber(self) -> str:
+    def primaryTelephoneNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's primary telephone.
         """
         return self._ensureSet('_primaryTelephoneNumber', '__substg1.0_3A1A')
 
     @property
-    def profession(self) -> str:
+    def profession(self) -> Optional[str]:
         """
         The profession of the contact.
         """
         return self._ensureSet('_profession', '__substg1.0_3A46')
 
     @property
-    def radioTelephoneNumber(self) -> str:
+    def radioTelephoneNumber(self) -> Optional[str]:
         """
         Contains the number of the contact's radio telephone.
         """
         return self._ensureSet('_radioTelephoneNumber', '__substg1.0_3A1D')
 
     @property
-    def referenceEntryID(self) -> EntryID:
+    def referenceEntryID(self) -> Optional[EntryID]:
         """
         Contains a value that is equal to the value of the EntryID of the
         Contact object unless the Contact object is a copy of an earlier
@@ -1248,28 +1248,28 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_referenceEntryID', '85BD', constants.PSETID_COMMON, overrideClass = EntryID.autoCreate)
 
     @property
-    def referredByName(self) -> str:
+    def referredByName(self) -> Optional[str]:
         """
         The name of the person who referred this contact to the user.
         """
         return self._ensureSet('_referredByName', '__substg1.0_3A47')
 
     @property
-    def spouseName(self) -> str:
+    def spouseName(self) -> Optional[str]:
         """
         The name of the contact's spouse.
         """
         return self._ensureSet('_spouseName', '__substg1.0_3A48')
 
     @property
-    def surname(self) -> str:
+    def surname(self) -> Optional[str]:
         """
         The surname of the contact.
         """
         return self._ensureSet('_surname', '__substg1.0_3A11')
 
     @property
-    def tddTelephoneNumber(self) -> str:
+    def tddTelephoneNumber(self) -> Optional[str]:
         """
         The telephone number for the contact's text telephone (TTY) or
         telecommunication device for the deaf (TDD).
@@ -1277,28 +1277,28 @@ class Contact(MessageBase):
         return self._ensureSet('_tddTelephoneNumber', '__substg1.0_3A4B')
 
     @property
-    def telexNumber(self) -> Union[str, List[str]]:
+    def telexNumber(self) -> Optional[Union[str, List[str]]]:
         """
         The contact's telex number(s).
         """
         return self._ensureSetTyped('_telexNumber', '3A2C')
 
     @property
-    def userX509Certificate(self) -> List[bytes]:
+    def userX509Certificate(self) -> Optional[List[bytes]]:
         """
         A list of certificates for the contact.
         """
         return self._ensureSetTyped('_userX509Certificate', '3A70')
 
     @property
-    def weddingAnniversary(self) -> datetime.datetime:
+    def weddingAnniversary(self) -> Optional[datetime.datetime]:
         """
         The wedding anniversary of the contact at 11:59 UTC.
         """
         return self._ensureSetProperty('_weddingAnniversary', '3A410040')
 
     @property
-    def weddingAnniversaryEventEntryID(self) -> EntryID:
+    def weddingAnniversaryEventEntryID(self) -> Optional[EntryID]:
         """
         The EntryID of an optional Appointement object that represents the
         contact's wedding anniversary.
@@ -1306,7 +1306,7 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_weddingAnniversaryEventEntryID', '804E', constants.PSETID_ADDRESS, overrideClass = EntryID.autoCreate)
 
     @property
-    def weddingAnniversaryLocal(self) -> datetime.datetime:
+    def weddingAnniversaryLocal(self) -> Optional[datetime.datetime]:
         """
         The wedding anniversary of the contact at 0:00 in the client's local
         time zone.
@@ -1314,63 +1314,63 @@ class Contact(MessageBase):
         return self._ensureSetNamed('_weddingAnniversaryLocal', '80DF', constants.PSETID_ADDRESS)
 
     @property
-    def webpageUrl(self) -> str:
+    def webpageUrl(self) -> Optional[str]:
         """
         The contact's business web page url. SHOULD be the same as businessUrl.
         """
         return self._ensureSetNamed('_webpageUrl', '802B', constants.PSETID_ADDRESS)
 
     @property
-    def workAddress(self) -> str:
+    def workAddress(self) -> Optional[str]:
         """
         The complete work address of the contact.
         """
         return self._ensureSetNamed('_workAddress', '801B', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressCountry(self) -> str:
+    def workAddressCountry(self) -> Optional[str]:
         """
         The country portion of the contact's work address.
         """
         return self._ensureSetNamed('_workAddressCountry', '8049', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressCountryCode(self) -> str:
+    def workAddressCountryCode(self) -> Optional[str]:
         """
         The country code portion of the contact's work address.
         """
         return self._ensureSetNamed('_workAddressCountryCode', '80DB', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressLocality(self) -> str:
+    def workAddressLocality(self) -> Optional[str]:
         """
         The locality or city portion of the contact's work address.
         """
         return self._ensureSetNamed('_workAddressLocality', '8046', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressPostalCode(self) -> str:
+    def workAddressPostalCode(self) -> Optional[str]:
         """
         The postal code portion of the contact's work address.
         """
         return self._ensureSetNamed('_workAddressPostalCode', '8048', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressPostOfficeBox(self) -> str:
+    def workAddressPostOfficeBox(self) -> Optional[str]:
         """
         The number or identifier of the contact's work post office box.
         """
         return self._ensureSetNamed('_workAddressPostOfficeBox', '804A', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressStateOrProvince(self) -> str:
+    def workAddressStateOrProvince(self) -> Optional[str]:
         """
         The state or province portion of the contact's work address.
         """
         return self._ensureSetNamed('_workAddressStateOrProvince', '8047', constants.PSETID_ADDRESS)
 
     @property
-    def workAddressStreet(self) -> str:
+    def workAddressStreet(self) -> Optional[str]:
         """
         The street portion of the contact's work address.
         """

--- a/extract_msg/dev_classes/message.py
+++ b/extract_msg/dev_classes/message.py
@@ -63,7 +63,7 @@ class Message(olefile.OleFileIO):
             else:
                 self.filename = None
 
-        self.mainProperties
+        self.props
         recipientDirs = []
 
         for dir_ in self.listDir():
@@ -161,8 +161,8 @@ class Message(olefile.OleFileIO):
         try:
             return self.__bStringsUnicode
         except AttributeError:
-            if self.mainProperties.has_key('340D0003'):
-                if (self.mainProperties['340D0003'].value & 0x40000) != 0:
+            if self.props.has_key('340D0003'):
+                if (self.props['340D0003'].value & 0x40000) != 0:
                     self.__bStringsUnicode = True
                     return self.__bStringsUnicode
             self.__bStringsUnicode = False
@@ -203,7 +203,7 @@ class Message(olefile.OleFileIO):
             return self._date
 
     @property
-    def mainProperties(self):
+    def props(self):
         """
         Returns the Properties instance used by the Message instance.
         """
@@ -274,11 +274,11 @@ class Message(olefile.OleFileIO):
                 return self.__stringEncoding
             else:
                 # Well, it's not unicode. Now we have to figure out what it IS.
-                if not self.mainProperties.has_key('3FFD0003'):
+                if not self.props.has_key('3FFD0003'):
                     logger.error("String encoding is not unicode, but was also not specified. Malformed MSG file detected. Defaulting to utf-8")
                     self.__stringEncoding = 'utf-8'
                     return self.__stringEncoding
-                enc = self.mainProperties['3FFD0003'].value
+                enc = self.props['3FFD0003'].value
                 # Now we just need to translate that value
                 # Now, this next line SHOULD work, but it is possible that it might not...
                 self.__stringEncoding = str(enc)

--- a/extract_msg/enums.py
+++ b/extract_msg/enums.py
@@ -397,12 +397,15 @@ class EntryIDType(enum.Enum):
         """
         return EntryIDTypeHex[self.name]
 
+    # This is the same as the one used for permanent IDs, and the strucutre is
+    # near identical too. Anything that needs a PermanentEntryID will need to
+    # specifically ask for it instead of autogenerating it.
     ADDRESS_BOOK_RECIPIENT = b'\xDC\xA7\x40\xC8\xC0\x42\x10\x1A\xB4\xB9\x08\x00\x2B\x2F\xE1\x82'
     # Contact address or personal distribution list recipient.
     CA_OR_PDL_RECIPIENT = b'\xFE\x42\xAA\x0A\x18\xC7\x1A\x10\xE8\x85\x0B\x65\x1C\x24\x00\x00'
+    # This is also used for the Store Object EntryID structure.
     NNTP_NEWSGROUP_FOLDER = b'\x38\xA1\xBB\x10\x05\xE5\x10\x1A\xA1\xBB\x08\x00\x2B\x2A\x56\xC2'
     ONE_OFF_RECIPIENT = b'\x81\x2B\x1F\xA4\xBE\xA3\x10\x19\x9D\x6E\x00\xDD\x01\x0F\x54\x02'
-    PERMANENT = b'\xDC\xA7\x40\xC8\xC0\x42\x10\x1A\xB4\xB9\x08\x00\x2B\x2F\xE1\x82'
     PUBLIC_MESSAGE_STORE = b'\x1A\x44\x73\x90\xAA\x66\x11\xCD\x9B\xC8\x00\xAA\x00\x2F\xC4\x5A'
     # [MS-OXOCNTC] WrappedEntryId Structure.
     WRAPPED = b'\xC0\x91\xAD\xD3\x51\x9D\xCF\x11\xA4\xA9\x00\xAA\x00\x47\xFA\xA4'
@@ -425,7 +428,6 @@ class EntryIDTypeHex(enum.Enum):
     CA_OR_PDL_RECIPIENT = 'FE42AA0A18C71A10E8850B651C240000'
     NNTP_NEWSGROUP_FOLDER = '38A1BB1005E5101AA1BB08002B2A56C2'
     ONE_OFF_RECIPIENT = '812B1FA4BEA310199D6E00DD010F5402'
-    PERMANENT = 'DCA740C8C042101AB4B908002B2FE182'
     PUBLIC_MESSAGE_STORE = '1A447390AA6611CD9BC800AA002FC45A'
     # [MS-OXOCNTC] WrappedEntryId Structure.
     WRAPPED = 'C091ADD3519DCF11A4A900AA0047FAA4'

--- a/extract_msg/meeting_exception.py
+++ b/extract_msg/meeting_exception.py
@@ -1,5 +1,7 @@
 import datetime
 
+from typing import Optional
+
 from . import constants
 from .meeting_related import MeetingRelated
 
@@ -21,7 +23,7 @@ class MeetingException(MeetingRelated):
         return self
 
     @property
-    def exceptionReplaceTime(self) -> datetime.datetime:
+    def exceptionReplaceTime(self) -> Optional[datetime.datetime]:
         """
         The date and time within the recurrence pattern that the exception will
         replace. The value is specified in UTC.
@@ -35,11 +37,11 @@ class MeetingException(MeetingRelated):
         differs from the Recurring Calendar object. If True, the Exception MUST
         have a body.
         """
-        return self._ensureSetNamed('_fExceptionalBody', '8206', constants.PSETID_APPOINTMENT)
+        return self._ensureSetNamed('_fExceptionalBody', '8206', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
     def fInvited(self) -> bool:
         """
         Indicates if invitations have been sent for this exception.
         """
-        return self._ensureSetNamed('_fInvited', '8229', constants.PSETID_APPOINTMENT)
+        return self._ensureSetNamed('_fInvited', '8229', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)

--- a/extract_msg/meeting_forward.py
+++ b/extract_msg/meeting_forward.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from . import constants
 from .meeting_related import MeetingRelated
 from .enums import BusyStatus, MeetingObjectChange, MeetingType, RecurCalendarType, RecurPatternType, ResponseStatus
@@ -9,7 +11,7 @@ class MeetingForwardNotification(MeetingRelated):
     """
 
     @property
-    def forwardNotificationRecipients(self) -> bytes:
+    def forwardNotificationRecipients(self) -> Optional[bytes]:
         """
         Bytes containing a list of RecipientRow structures that indicate the
         recipients of a meeting forward.
@@ -87,4 +89,4 @@ class MeetingForwardNotification(MeetingRelated):
         Indicates that the Meeting Forward Notification object was out-of-date
         when it was received.
         """
-        return self._ensureSetNamed('_promptSendUpdate', '8045', constants.PSETID_COMMON)
+        return self._ensureSetNamed('_promptSendUpdate', '8045', constants.PSETID_COMMON, overrideClass = bool, preserveNone = False)

--- a/extract_msg/meeting_related.py
+++ b/extract_msg/meeting_related.py
@@ -1,6 +1,6 @@
 import datetime
 
-from typing import Set
+from typing import Optional, Set
 
 from . import constants
 from .calendar_base import CalendarBase
@@ -13,7 +13,7 @@ class MeetingRelated(CalendarBase):
     """
 
     @property
-    def attendeeCriticalChange(self) -> datetime.datetime:
+    def attendeeCriticalChange(self) -> Optional[datetime.datetime]:
         """
         The date and time at which the meeting-related object was sent.
         """
@@ -24,7 +24,7 @@ class MeetingRelated(CalendarBase):
         """
         Indicates whether a client has processed a meeting-related object.
         """
-        return self._ensureSetProperty('_processed', '7D01000B')
+        return self._ensureSetProperty('_processed', '7D01000B', overrideClass = bool, preserveNone = False)
 
     @property
     def serverProcessed(self) -> bool:
@@ -32,10 +32,10 @@ class MeetingRelated(CalendarBase):
         Indicates that the Meeting Request object or Meeting Update object has
         been processed.
         """
-        return self._ensureSetNamed('_serverProcessed', '85CC', constants.PSETID_CALENDAR_ASSISTANT)
+        return self._ensureSetNamed('_serverProcessed', '85CC', constants.PSETID_CALENDAR_ASSISTANT, overrideClass = bool, preserveNone = False)
 
     @property
-    def serverProcessingActions(self) -> Set[ServerProcessingAction]:
+    def serverProcessingActions(self) -> Optional[Set[ServerProcessingAction]]:
         """
         A set of which actions have been taken on the Meeting Request object or
         Meeting Update object.
@@ -43,7 +43,7 @@ class MeetingRelated(CalendarBase):
         return self._ensureSetNamed('_serverProcessingActions', '85CD', constants.PSETID_CALENDAR_ASSISTANT, overrideClass = ServerProcessingAction.fromBits)
 
     @property
-    def timeZone(self) -> int:
+    def timeZone(self) -> Optional[int]:
         """
         Specifies information about the time zone of a recurring meeting.
 
@@ -52,7 +52,7 @@ class MeetingRelated(CalendarBase):
         return self._ensureSetNamed('_timeZone', '000C', constants.PSETID_MEETING)
 
     @property
-    def where(self) -> str:
+    def where(self) -> Optional[str]:
         """
         PidLidWhere. Should be the same as location.
         """

--- a/extract_msg/meeting_request.py
+++ b/extract_msg/meeting_request.py
@@ -1,6 +1,6 @@
 import datetime
 
-from typing import List, Set
+from typing import List, Optional, Set
 
 from . import constants
 from .meeting_related import MeetingRelated
@@ -13,7 +13,7 @@ class MeetingRequest(MeetingRelated):
     """
 
     @property
-    def appointmentMessageClass(self) -> str:
+    def appointmentMessageClass(self) -> Optional[str]:
         """
         Indicates the value of the PidTagMessageClass property of the Meeting
         object that is to be generated from the Meeting Request object. MUST
@@ -22,7 +22,7 @@ class MeetingRequest(MeetingRelated):
         return self._ensureSetNamed('_appointmentMessageClass', '0024', constants.PSETID_MEETING)
 
     @property
-    def calendarType(self) -> RecurCalendarType:
+    def calendarType(self) -> Optional[RecurCalendarType]:
         """
         The value of the CalendarType field from the PidLidAppointmentRecur
         property if the Meeting Request object represents a recurring series or
@@ -31,7 +31,7 @@ class MeetingRequest(MeetingRelated):
         return self._ensureSetNamed('_calendarType', '001C', constants.PSETID_MEETING, overrideClass = RecurCalendarType)
 
     @property
-    def changeHighlight(self) -> Set[MeetingObjectChange]:
+    def changeHighlight(self) -> Optional[Set[MeetingObjectChange]]:
         """
         Soecifies a bit field that indicates how the Meeting object has been
         changed.
@@ -47,7 +47,7 @@ class MeetingRequest(MeetingRelated):
         recurring series, and it was forwarded (even when forwarded by the
         organizer) rather than being an invitation sent by the organizer.
         """
-        return self._ensureSetNamed('_forwardInstance', '820A', constants.PSETID_APPOINTMENT)
+        return self._ensureSetNamed('_forwardInstance', '820A', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
     def headerFormatProperties(self) -> constants.HEADER_FORMAT_TYPE:
@@ -128,7 +128,7 @@ class MeetingRequest(MeetingRelated):
 
 
     @property
-    def intendedBusyStatus(self) -> BusyStatus:
+    def intendedBusyStatus(self) -> Optional[BusyStatus]:
         """
         The value of the busyStatus on the Meeting object in the organizer's
         calendar at the time the Meeting Request object or Meeting Update object
@@ -137,21 +137,21 @@ class MeetingRequest(MeetingRelated):
         return self._ensureSetNamed('_intendedBusyStatus', '8224', constants.PSETID_APPOINTMENT, overrideClass = BusyStatus)
 
     @property
-    def meetingType(self) -> MeetingType:
+    def meetingType(self) -> Optional[MeetingType]:
         """
         The type of Meeting Request object or Meeting Update object.
         """
         return self._ensureSetNamed('_meetingType', '0026', constants.PSETID_MEETING, overrideClass = MeetingType)
 
     @property
-    def oldLocation(self) -> str:
+    def oldLocation(self) -> Optional[str]:
         """
         The original value of the location property before a meeting update.
         """
         return self._ensureSetNamed('_oldLocation', '0028', constants.PSETID_MEETING)
 
     @property
-    def oldWhenEndWhole(self) -> datetime.datetime:
+    def oldWhenEndWhole(self) -> Optional[datetime.datetime]:
         """
         The original value of the appointmentEndWhole property before a meeting
         update.
@@ -159,7 +159,7 @@ class MeetingRequest(MeetingRelated):
         return self._ensureSetNamed('_oldWhenEndWhole', '002A', constants.PSETID_MEETING)
 
     @property
-    def oldWhenStartWhole(self) -> datetime.datetime:
+    def oldWhenStartWhole(self) -> Optional[datetime.datetime]:
         """
         The original value of the appointmentStartWhole property before a
         meeting update.

--- a/extract_msg/meeting_response.py
+++ b/extract_msg/meeting_response.py
@@ -1,5 +1,7 @@
 import datetime
 
+from typing import Optional
+
 from . import constants
 from .enums import ResponseType
 from .meeting_related import MeetingRelated
@@ -15,10 +17,10 @@ class MeetingResponse(MeetingRelated):
         """
         Indicates if the response is a counter proposal.
         """
-        return self._ensureSetNamed('_appointmentCounterProposal', '8257', constants.PSETID_APPOINTMENT)
+        return self._ensureSetNamed('_appointmentCounterProposal', '8257', constants.PSETID_APPOINTMENT, overrideClass = bool, preserveNone = False)
 
     @property
-    def appointmentProposedDuration(self) -> int:
+    def appointmentProposedDuration(self) -> Optional[int]:
         """
         The proposed value for the appointmentDuration property for a counter
         proposal.
@@ -26,7 +28,7 @@ class MeetingResponse(MeetingRelated):
         return self._ensureSetNamed('_appointmentProposedDuration', '8256', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentProposedEndWhole(self) -> datetime.datetime:
+    def appointmentProposedEndWhole(self) -> Optional[datetime.datetime]:
         """
         The proposal value for the appointmentEndWhole property for a counter
         proposal.
@@ -34,7 +36,7 @@ class MeetingResponse(MeetingRelated):
         return self._ensureSetNamed('_appointmentProposedEndWhole', '8251', constants.PSETID_APPOINTMENT)
 
     @property
-    def appointmentProposedStartWhole(self) -> datetime.datetime:
+    def appointmentProposedStartWhole(self) -> Optional[datetime.datetime]:
         """
         The proposal value for the appointmentStartWhole property for a counter
         proposal.
@@ -47,7 +49,7 @@ class MeetingResponse(MeetingRelated):
         Indicates if the user did not include any text in the body of the
         Meeting Response object.
         """
-        return self._ensureSetNamed('_isSilent', '0004', constants.PSETID_MEETING)
+        return self._ensureSetNamed('_isSilent', '0004', constants.PSETID_MEETING, overrideClass = bool, preserveNone = False)
 
     @property
     def promptSendUpdate(self) -> bool:
@@ -55,10 +57,10 @@ class MeetingResponse(MeetingRelated):
         Indicates that the Meeting Response object was out-of-date when it was
         received.
         """
-        return self._ensureSetNamed('_promptSendUpdate', '8045', constants.PSETID_COMMON)
+        return self._ensureSetNamed('_promptSendUpdate', '8045', constants.PSETID_COMMON, overrideClass = bool, preserveNone = False)
 
     @property
-    def responseType(self) -> ResponseType:
+    def responseType(self) -> Optional[ResponseType]:
         """
         The type of Meeting Response object.
         """

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -16,7 +16,7 @@ import compressed_rtf
 import RTFDE
 
 from email.parser import Parser as EmailParser
-from typing import Callable, Dict, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 from . import constants
 from .enums import DeencapType, RecipientType
@@ -25,6 +25,7 @@ from .exceptions import (
         IncompatibleOptionsError, WKError
     )
 from .msg import MSGFile
+from .structures.report_tag import ReportTag
 from .recipient import Recipient
 from .utils import (
         addNumToDir, addNumToZipDir, createZipOpen, findWk, htmlSanitize,
@@ -108,7 +109,7 @@ class MessageBase(MSGFile):
         self.named
         self.namedProperties
 
-    def _genRecipient(self, recipientType, recipientInt : RecipientType):
+    def _genRecipient(self, recipientType, recipientInt : RecipientType) -> Optional[str]:
         """
         Returns the specified recipient field.
         """
@@ -154,7 +155,7 @@ class MessageBase(MSGFile):
 
             return value
 
-    def deencapsulateBody(self, rtfBody : bytes, bodyType : DeencapType):
+    def deencapsulateBody(self, rtfBody : bytes, bodyType : DeencapType) -> Optional[Union[bytes, str]]:
         """
         A function to deencapsulate the specified body from the rtfBody. Returns
         a string for plain text and bytes for HTML. If specified, uses the
@@ -878,14 +879,14 @@ class MessageBase(MSGFile):
         return self
 
     @property
-    def bcc(self):
+    def bcc(self) -> Optional[str]:
         """
         Returns the bcc field, if it exists.
         """
         return self._genRecipient('bcc', RecipientType.BCC)
 
     @property
-    def body(self):
+    def body(self) -> Optional[str]:
         """
         Returns the message body, if it exists.
         """
@@ -909,21 +910,21 @@ class MessageBase(MSGFile):
             return self._body
 
     @property
-    def cc(self):
+    def cc(self) -> Optional[str]:
         """
         Returns the cc field, if it exists.
         """
         return self._genRecipient('cc', RecipientType.CC)
 
     @property
-    def compressedRtf(self):
+    def compressedRtf(self) -> Optional[bytes]:
         """
         Returns the compressed RTF stream, if it exists.
         """
         return self._ensureSet('_compressedRtf', '__substg1.0_10090102', False)
 
     @property
-    def crlf(self):
+    def crlf(self) -> str:
         """
         Returns the value of self.__crlf, should you need it for whatever
         reason.
@@ -932,7 +933,7 @@ class MessageBase(MSGFile):
         return self.__crlf
 
     @property
-    def date(self):
+    def date(self) -> Optional[str]:
         """
         Returns the send date, if it exists.
         """
@@ -943,7 +944,7 @@ class MessageBase(MSGFile):
             return self._date
 
     @property
-    def deencapsulatedRtf(self) -> RTFDE.DeEncapsulator:
+    def deencapsulatedRtf(self) -> Optional[RTFDE.DeEncapsulator]:
         """
         Returns the instance of the deencapsulated RTF body. If there is no RTF
         body or the body is not encasulated, returns None.
@@ -1104,7 +1105,7 @@ class MessageBase(MSGFile):
         }
 
     @property
-    def htmlBody(self) -> bytes:
+    def htmlBody(self) -> Optional[bytes]:
         """
         Returns the html body, if it exists.
         """
@@ -1131,7 +1132,7 @@ class MessageBase(MSGFile):
             return self._htmlBody
 
     @property
-    def htmlBodyPrepared(self) -> bytes:
+    def htmlBodyPrepared(self) -> Optional[bytes]:
         """
         Returns the HTML body that has (where possible) the embedded attachments
         inserted into the body.
@@ -1171,7 +1172,7 @@ class MessageBase(MSGFile):
         return self.getInjectableHeader(prefix, joinStr, suffix, formatter)
 
     @property
-    def inReplyTo(self) -> str:
+    def inReplyTo(self) -> Optional[str]:
         """
         Returns the message id that this message is in reply to.
         """
@@ -1196,7 +1197,7 @@ class MessageBase(MSGFile):
             return not bool(self.mainProperties['0E070003'].value & 8)
 
     @property
-    def messageId(self) -> str:
+    def messageId(self) -> Optional[str]:
         try:
             return self._messageId
         except AttributeError:
@@ -1216,7 +1217,7 @@ class MessageBase(MSGFile):
         return email.utils.parsedate(self.date)
 
     @property
-    def receivedTime(self) -> datetime.datetime:
+    def receivedTime(self) -> Optional[datetime.datetime]:
         """
         The date and time the message was received by the server.
         """
@@ -1250,7 +1251,14 @@ class MessageBase(MSGFile):
             return self._recipients
 
     @property
-    def rtfBody(self) -> bytes:
+    def reportTag(self) -> Optional[ReportTag]:
+        """
+        Data that is used to correlate the report and the original message.
+        """
+        return self.__ensureSet('_reportTag', '__substg1.0_00310102', False, overrideClass = ReportTag)
+
+    @property
+    def rtfBody(self) -> Optional[bytes]:
         """
         Returns the decompressed Rtf body from the message.
         """
@@ -1286,7 +1294,7 @@ class MessageBase(MSGFile):
         return self.getInjectableHeader(prefix, joinStr, suffix, formatter)
 
     @property
-    def sender(self) -> str:
+    def sender(self) -> Optional[str]:
         """
         Returns the message sender, if it exists.
         """
@@ -1316,14 +1324,14 @@ class MessageBase(MSGFile):
             return result
 
     @property
-    def subject(self):
+    def subject(self) -> Optional[str]:
         """
         Returns the message subject, if it exists.
         """
         return self._ensureSet('_subject', '__substg1.0_0037')
 
     @property
-    def to(self):
+    def to(self) -> Optional[str]:
         """
         Returns the to field, if it exists.
         """

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -91,7 +91,7 @@ class MessageBase(MSGFile):
         # Initialize properties in the order that is least likely to cause bugs.
         # TODO have each function check for initialization of needed data so
         # these lines will be unnecessary.
-        self.mainProperties
+        self.props
         self.header
         self.recipients
 
@@ -1183,7 +1183,7 @@ class MessageBase(MSGFile):
         """
         Returns if this email has been marked as read.
         """
-        return bool(self.mainProperties['0E070003'].value & 1)
+        return bool(self.props['0E070003'].value & 1)
 
     @property
     def isSent(self) -> bool:
@@ -1191,10 +1191,10 @@ class MessageBase(MSGFile):
         Returns if this email has been marked as sent. Assumes True if no flags
         are found.
         """
-        if not self.mainProperties.get('0E070003'):
+        if not self.props.get('0E070003'):
             return True
         else:
-            return not bool(self.mainProperties['0E070003'].value & 8)
+            return not bool(self.props['0E070003'].value & 8)
 
     @property
     def messageId(self) -> Optional[str]:

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -1255,7 +1255,7 @@ class MessageBase(MSGFile):
         """
         Data that is used to correlate the report and the original message.
         """
-        return self.__ensureSet('_reportTag', '__substg1.0_00310102', False, overrideClass = ReportTag)
+        return self._ensureSet('_reportTag', '__substg1.0_00310102', False, overrideClass = ReportTag)
 
     @property
     def rtfBody(self) -> Optional[bytes]:

--- a/extract_msg/message_signed_base.py
+++ b/extract_msg/message_signed_base.py
@@ -3,6 +3,8 @@ import html
 import logging
 import re
 
+from typing import List, Optional
+
 from .exceptions import StandardViolationError
 from .message_base import MessageBase
 from .signed_attachment import SignedAttachment
@@ -54,7 +56,7 @@ class MessageSignedBase(MessageBase):
             self.attachments
 
     @property
-    def attachments(self) -> list:
+    def attachments(self) -> List:
         """
         Returns a list of all attachments.
 
@@ -76,12 +78,12 @@ class MessageSignedBase(MessageBase):
             # attachments.
             self._sAttachments = [self.__signedAttachmentClass(self, **att) for att in unwrapped['attachments']]
             self._signedBody = unwrapped['plain_body']
-            self._signedHtmlBody = unwrapped['html_body']
+            self._signedHtmlBody = inputToBytes(unwrapped['html_body'], 'utf-8')
 
             return self._sAttachments
 
     @property
-    def body(self):
+    def body(self) -> Optional[str]:
         """
         Returns the message body, if it exists.
         """
@@ -107,7 +109,7 @@ class MessageSignedBase(MessageBase):
             return self._body
 
     @property
-    def htmlBody(self) -> bytes:
+    def htmlBody(self) -> Optional[bytes]:
         """
         Returns the html body, if it exists.
         """
@@ -136,7 +138,7 @@ class MessageSignedBase(MessageBase):
             return self._htmlBody
 
     @property
-    def _rawAttachments(self):
+    def _rawAttachments(self) -> List:
         """
         A property to allow access to the non-signed attachments.
         """
@@ -150,7 +152,7 @@ class MessageSignedBase(MessageBase):
         return self.__signedAttachmentClass
 
     @property
-    def signedBody(self):
+    def signedBody(self) -> Optional[str]:
         """
         Returns the body from the signed message if it exists.
         """
@@ -161,7 +163,7 @@ class MessageSignedBase(MessageBase):
             return self._signedBody
 
     @property
-    def signedHtmlBody(self):
+    def signedHtmlBody(self) -> Optional[bytes]:
         """
         Returns the HTML body from the signed message if it exists.
         """

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -9,6 +9,7 @@ import zipfile
 import olefile
 
 from typing import List, Optional, Set, Union
+from warnings import warn
 
 from . import constants
 from .attachment import Attachment, BrokenAttachment, UnsupportedAttachment
@@ -705,9 +706,8 @@ class MSGFile:
 
     @property
     def mainProperties(self) -> Properties:
-        warnings.warn('`MSGFile.mainProperties` is deprecated and will soon' + \
-                      ' be removed. Please use `MSGFile.props` instead.',
-                      warnings.DeprecationWarning)
+        warn('`MSGFile.mainProperties` is deprecated and will soon be ' + \
+             'removed. Please use `MSGFile.props` instead.', DeprecationWarning)
         return self.props
 
     @property

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -8,7 +8,7 @@ import zipfile
 
 import olefile
 
-from typing import List, Set, Union
+from typing import List, Optional, Set, Union
 
 from . import constants
 from .attachment import Attachment, BrokenAttachment, UnsupportedAttachment
@@ -269,7 +269,7 @@ class MSGFile:
             setattr(self, variable, value)
             return value
 
-    def _getStream(self, filename, prefix : bool = True) -> bytes:
+    def _getStream(self, filename, prefix : bool = True) -> Optional[bytes]:
         """
         Gets a binary representation of the requested filename.
 
@@ -284,7 +284,7 @@ class MSGFile:
             logger.info(f'Stream "{filename}" was requested but could not be found. Returning `None`.')
             return None
 
-    def _getStringStream(self, filename, prefix : bool = True) -> str:
+    def _getStringStream(self, filename, prefix : bool = True) -> Optional[str]:
         """
         Gets a string representation of the requested filename.
 
@@ -464,7 +464,7 @@ class MSGFile:
                     foundNumber += 1
         return (foundNumber > 0), foundNumber
 
-    def fixPath(self, inp, prefix : bool = True):
+    def fixPath(self, inp, prefix : bool = True) -> str:
         """
         Changes paths so that they have the proper prefix (should :param prefix:
         be True) and are strings rather than lists or tuples.
@@ -637,31 +637,31 @@ class MSGFile:
         Indicates whether the contents of this message are regarded as
         classified information.
         """
-        return self._ensureSetNamed('_classified', '85B5', constants.PSETID_COMMON)
+        return self._ensureSetNamed('_classified', '85B5', constants.PSETID_COMMON, overrideClass = bool, preserveNone = False)
 
     @property
-    def classType(self) -> str:
+    def classType(self) -> Optional[str]:
         """
         The class type of the MSG file.
         """
         return self._ensureSet('_classType', '__substg1.0_001A')
 
     @property
-    def commonEnd(self) -> datetime.datetime:
+    def commonEnd(self) -> Optional[datetime.datetime]:
         """
         The end time for the object.
         """
         return self._ensureSetNamed('_commonEnd', '8517', constants.PSETID_COMMON)
 
     @property
-    def commonStart(self) -> datetime.datetime:
+    def commonStart(self) -> Optional[datetime.datetime]:
         """
         The start time for the object.
         """
         return self._ensureSetNamed('_commonStart', '8516', constants.PSETID_COMMON)
 
     @property
-    def currentVersion(self) -> int:
+    def currentVersion(self) -> Optional[int]:
         """
         Specifies the build number of the client application that sent the
         message.
@@ -669,14 +669,14 @@ class MSGFile:
         return self._ensureSetNamed('_currentVersion', '8552', constants.PSETID_COMMON)
 
     @property
-    def currentVersionName(self) -> str:
+    def currentVersionName(self) -> Optional[str]:
         """
         Specifies the name of the client application that sent the message.
         """
         return self._ensureSetNamed('_currentVersionName', '8554', constants.PSETID_COMMON)
 
     @property
-    def importance(self) -> Importance:
+    def importance(self) -> Optional[Importance]:
         """
         The specified importance of the msg file.
         """
@@ -788,21 +788,21 @@ class MSGFile:
         return copy.deepcopy(self.__prefixList)
 
     @property
-    def priority(self) -> Priority:
+    def priority(self) -> Optional[Priority]:
         """
         The specified priority of the msg file.
         """
         return self._ensureSetProperty('_priority', '00260003', overrideClass = Priority)
 
     @property
-    def sensitivity(self) -> Sensitivity:
+    def sensitivity(self) -> Optional[Sensitivity]:
         """
         The specified sensitivity of the msg file.
         """
         return self._ensureSetProperty('_sensitivity', '00360003', overrideClass = Sensitivity)
 
     @property
-    def sideEffects(self) -> Set[SideEffect]:
+    def sideEffects(self) -> Optional[Set[SideEffect]]:
         """
         Controls how a Message object is handled by the client in relation to
         certain user interface actions by the user, such as deleting a message.

--- a/extract_msg/named.py
+++ b/extract_msg/named.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import pprint
 
-from typing import Optional
+from typing import Dict, Optional
 
 from . import constants
 from .enums import NamedPropertyType

--- a/extract_msg/named.py
+++ b/extract_msg/named.py
@@ -77,7 +77,7 @@ class Named:
     def __iter__(self):
         return self.__propertiesDict.__iter__()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.__propertiesDict.__len__()
 
     def _getStream(self, filename, prefix = True) -> Optional[bytes]:
@@ -139,14 +139,14 @@ class Named:
         return self.__dir
 
     @property
-    def msg(self):
+    def msg(self) -> 'MSGFile':
         """
         Returns the Message instance the attachment belongs to.
         """
         return self.__msg
 
     @property
-    def namedProperties(self):
+    def namedProperties(self) -> Dict:
         """
         Returns a copy of the dictionary containing all the named properties.
         """

--- a/extract_msg/named.py
+++ b/extract_msg/named.py
@@ -2,6 +2,8 @@ import copy
 import logging
 import pprint
 
+from typing import Optional
+
 from . import constants
 from .enums import NamedPropertyType
 from .utils import bytesToGuid, divide, properHex, roundUp
@@ -78,10 +80,10 @@ class Named:
     def __len__(self):
         return self.__propertiesDict.__len__()
 
-    def _getStream(self, filename, prefix = True):
+    def _getStream(self, filename, prefix = True) -> Optional[bytes]:
         return self.__msg._getStream([self.__dir, filename], prefix = prefix)
 
-    def _getStringStream(self, filename, prefix = True):
+    def _getStringStream(self, filename, prefix = True) -> Optional[str]:
         """
         Gets a string representation of the requested filename.
         Checks for both ASCII and Unicode representations and returns
@@ -91,13 +93,13 @@ class Named:
         """
         return self.__msg._getStringStream([self.__dir, filename], prefix = prefix)
 
-    def exists(self, filename):
+    def exists(self, filename) -> bool:
         """
         Checks if stream exists inside the named properties folder.
         """
         return self.__msg.exists([self.__dir, filename])
 
-    def sExists(self, filename):
+    def sExists(self, filename) -> bool:
         """
         Checks if the string stream exists inside the named properties folder.
         """
@@ -198,28 +200,28 @@ class NamedPropertyBase:
         self.__propertyStreamID = f'{0x8000 + self.__namedPropertyID:04X}'
 
     @property
-    def guid(self):
+    def guid(self) -> str:
         """
         The guid of the property's property set.
         """
         return self.__guid
 
     @property
-    def guidIndex(self):
+    def guidIndex(self) -> int:
         """
         The guid index of the property's property set.
         """
         return self.__guidIndex
 
     @property
-    def namedPropertyID(self):
+    def namedPropertyID(self) -> int:
         """
         The named property id.
         """
         return self.__namedPropertyID
 
     @property
-    def propertyStreamID(self):
+    def propertyStreamID(self) -> str:
         """
         An ID usable for grabbing the value stream.
         """
@@ -230,11 +232,18 @@ class NamedPropertyBase:
         return copy.deepcopy(entry)
 
     @property
-    def rawEntryStream(self):
+    def rawEntryStream(self) -> bytes:
         """
         The raw data used for the entry.
         """
         return self.__entry['rawStream']
+
+    @property
+    def type(self) -> NamedPropertyType:
+        """
+        The type of named property.
+        """
+        raise NotImplementedError('NamedPropertyBase cannot be used directly. Subclass it before using it.')
 
 
 
@@ -271,21 +280,21 @@ class StringNamedProperty(NamedPropertyBase):
             self.__streamID = 0x1000 + (crc32(name.encode('utf-16-le')) ^ (self.guidIndex << 1 | 1)) % 0x1F
 
     @property
-    def name(self):
+    def name(self) -> str:
         """
         The name of the property.
         """
         return self.__name
 
     @property
-    def streamID(self):
+    def streamID(self) -> int:
         """
         Returns the streamID of the named property. This may not be accurate.
         """
         return self.__streamID
 
     @property
-    def type(self):
+    def type(self) -> NamedPropertyType:
         """
         Returns the type of the named property. This will either be NUMERICAL_NAMED or STRING_NAMED.
         """
@@ -300,21 +309,21 @@ class NumericalNamedProperty(NamedPropertyBase):
         self.__streamID = 0x1000 + (entry['id'] ^ (self.guidIndex << 1)) % 0x1F
 
     @property
-    def propertyID(self):
+    def propertyID(self) -> str:
         """
         The actualy property id of the named property.
         """
         return self.__propertyID
 
     @property
-    def streamID(self):
+    def streamID(self) -> int:
         """
         Returns the streamID of the named property. This may not be accurate
         """
         return self.__streamID
 
     @property
-    def type(self):
+    def type(self) -> NamedPropertyType:
         """
         Returns the type of the named property. This will either be NUMERICAL_NAMED or STRING_NAMED.
         """

--- a/extract_msg/post.py
+++ b/extract_msg/post.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from . import constants
 from .message_base import MessageBase
 from .utils import inputToBytes, inputToString
@@ -21,7 +23,7 @@ class Post(MessageBase):
         })
 
     @property
-    def conversation(self) -> str:
+    def conversation(self) -> Optional[str]:
         """
         The name of the conversation being posted to.
         """

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -14,15 +14,15 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def createProp(string) -> 'PropBase':
-    temp = constants.ST2.unpack(string)[0]
+def createProp(data : bytes) -> 'PropBase':
+    temp = constants.ST2.unpack(data)[0]
     if temp in constants.FIXED_LENGTH_PROPS:
-        return FixedLengthProp(string)
+        return FixedLengthProp(data)
     else:
         if temp not in constants.VARIABLE_LENGTH_PROPS:
             # DEBUG
             logger.warning(f'Unknown property type: {properHex(temp)}')
-        return VariableLengthProp(string)
+        return VariableLengthProp(data)
 
 
 class PropBase:
@@ -32,8 +32,8 @@ class PropBase:
 
     def __init__(self, data : bytes):
         self.__rawData = data
-        self.__name = properHex(string[3::-1]).upper()
-        self.__type, self.__flags = constants.ST2.unpack(string)
+        self.__name = properHex(data[3::-1]).upper()
+        self.__type, self.__flags = constants.ST2.unpack(data)
         self.__fm = self.__flags & 1 == 1
         self.__fr = self.__flags & 2 == 2
         self.__fw = self.__flags & 4 == 4

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def createProp(string):
+def createProp(string) -> 'PropBase':
     temp = constants.ST2.unpack(string)[0]
     if temp in constants.FIXED_LENGTH_PROPS:
         return FixedLengthProp(string)
@@ -192,14 +192,14 @@ class VariableLengthProp(PropBase):
             self.__realLength = self.__length
 
     @property
-    def length(self):
+    def length(self) -> int:
         """
         The length field of the variable length property.
         """
         return self.__length
 
     @property
-    def realLength(self):
+    def realLength(self) -> int:
         """
         The ACTUAL length of the stream that this property corresponds to.
         """

--- a/extract_msg/recipient.py
+++ b/extract_msg/recipient.py
@@ -119,7 +119,7 @@ class Recipient:
             setattr(self, variable, value)
             return value
 
-    def _getStream(self, filename):
+    def _getStream(self, filename) -> Optional[bytes]:
         """
         Gets a binary representation of the requested filename.
 
@@ -128,7 +128,7 @@ class Recipient:
         """
         return self.__msg._getStream([self.__dir, filename])
 
-    def _getStringStream(self, filename):
+    def _getStringStream(self, filename) -> Optional[str]:
         """
         Gets a string representation of the requested filename. Checks for both
         Unicode and Non-Unicode representations and returns a value if possible.
@@ -249,7 +249,7 @@ class Recipient:
         return self._ensureSet('_instanceKey', '__substg1.0_0FF60102', False)
 
     @property
-    def name(self):
+    def name(self) -> Optional[str]:
         """
         Returns the recipient's name.
         """

--- a/extract_msg/recipient.py
+++ b/extract_msg/recipient.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Union
+from typing import Optional, Union
 
 from .enums import MeetingRecipientType, PropertiesType, RecipientType
 from .prop import FixedLengthProp
@@ -214,29 +214,25 @@ class Recipient:
         return self.__msg.existsTypedProperty(id, self.__dir, _type, True, self.__props)
 
     @property
-    def account(self):
+    def account(self) -> Optional[str]:
         """
         Returns the account of this recipient.
         """
         return self._ensureSet('_account', '__substg1.0_3A00')
 
     @property
-    def email(self):
+    def email(self) -> Optional[str]:
         """
         Returns the recipient's email.
         """
         return self.__email
 
     @property
-    def entryID(self):
+    def entryID(self) -> Optional[PermanentEntryID]:
         """
         Returns the recipient's Entry ID.
         """
-        try:
-            return self.__entryID
-        except AttributeError:
-            self.__entryID = PermanentEntryID(self._getStream('__substg1.0_0FFF0102'))
-            return self.__entryID
+        return self._ensureSet('_entryID', '__substg1.0_0FFF0102', False, overrideClass = PermanentEntryID)
 
     @property
     def formatted(self) -> str:
@@ -246,7 +242,7 @@ class Recipient:
         return self.__formatted
 
     @property
-    def instanceKey(self):
+    def instanceKey(self) -> Optional[bytes]:
         """
         Returns the instance key of this recipient.
         """
@@ -267,28 +263,28 @@ class Recipient:
         return self.__props
 
     @property
-    def recordKey(self):
+    def recordKey(self) -> Optional[bytes]:
         """
         Returns the instance key of this recipient.
         """
         return self._ensureSet('_recordKey', '__substg1.0_0FF90102', False)
 
     @property
-    def searchKey(self):
+    def searchKey(self) -> Optional[bytes]:
         """
         Returns the search key of this recipient.
         """
         return self._ensureSet('_searchKey', '__substg1.0_300B0102', False)
 
     @property
-    def smtpAddress(self):
+    def smtpAddress(self) -> Optional[str]:
         """
         Returns the SMTP address of this recipient.
         """
         return self._ensureSet('_smtpAddress', '__substg1.0_39FE')
 
     @property
-    def transmittableDisplayName(self):
+    def transmittableDisplayName(self) -> Optional[str]:
         """
         Returns the transmittable display name of this recipient.
         """

--- a/extract_msg/structures/report_tag.py
+++ b/extract_msg/structures/report_tag.py
@@ -1,0 +1,117 @@
+from typing import Optional
+
+from ._helpers import BytesReader
+from .entry_id import EntryID
+
+
+class ReportTag:
+    """
+    A Report Tag structure, as defined in [MS-OXOMSG].
+    """
+
+    def __init__(self, data : bytes):
+        self.__rawData = data
+        reader = BytesReader(reader)
+
+        self.__cookie = reader.assertRead(b'PCDFEB09\x00')
+
+        self.__version = reader.readUnsignedInt()
+        entrySize = reader.readInt()
+        if entrySize:
+            self.__storeEntryID = EntryID.autoCreate(reader.read(entrySize))
+        else:
+            self.__storeEntryID = None
+
+        entrySize = reader.readInt()
+        if entrySize:
+            self.__folderEntryID = EntryID.autoCreate(reader.read(entrySize))
+        else:
+            self.__folderEntryID = None
+
+        entrySize = reader.readInt()
+        if entrySize:
+            self.__messageEntryID = EntryID.autoCreate(reader.read(entrySize))
+        else:
+            self.__messageEntryID = None
+
+        entrySize = reader.readInt()
+        if entrySize:
+            self.__searchFolderEntryID = EntryID.autoCreate(reader.read(entrySize))
+        else:
+            self.__searchFolderEntryID = None
+
+        entrySize = reader.readInt()
+        if entrySize:
+            self.__messageSearchKey = reader.read(entrySize)
+        else:
+            self.__messageSearchKey = None
+
+        entrySize = reader.readInt()
+        if entrySize:
+            self.__ansiText = reader.read(entrySize)
+        else:
+            self.__ansiText = None
+
+    @property
+    def ansiText(self) -> Optional[bytes]:
+        """
+        The subject of the original message. Set to None if not present.
+        """
+        return self.__ansiText
+
+    @property
+    def cookie(self) -> bytes:
+        """
+        String used for validation. Set to b'PCDFEB09\x00'.
+        """
+        return self.__cookie
+
+    @property
+    def folderEntryID(self) -> Optional[EntryID]:
+        """
+        The EntryID of the folder than contains the original message.
+        """
+        return self.__folderEntryID
+
+    @property
+    def messageEntryID(self) -> Optional[EntryID]:
+        """
+        The EntryID of the original message.
+        """
+        return self.__messageEntryID
+
+    @property
+    def messageSearchKey(self) -> Optional[bytes]:
+        """
+        The search key of the original message.
+        """
+        return self.__messageSearchKey
+
+    @property
+    def rawData(self) -> bytes:
+        """
+        The raw bytes used to create this object.
+        """
+        return self.__rawData
+
+    @property
+    def searchFolderEntryID(self) -> Optional[EntryID]:
+        """
+        The EntryID of an alternate folder that contains the original message.
+        """
+        return self.__searchFolderEntryID
+
+    @property
+    def storeEntryID(self) -> Optional[EntryID]:
+        """
+        The EntryID of the mailbox that contains the original message.
+        """
+        return self.__storeEntryID
+
+    @property
+    def version(self) -> int:
+        """
+        The version used. If SearchFolderEntryID is present, this MUST be
+        0x00020001, otherwise it MUST be 0x00010001.
+        """
+        return self.__version

--- a/extract_msg/structures/report_tag.py
+++ b/extract_msg/structures/report_tag.py
@@ -11,7 +11,7 @@ class ReportTag:
 
     def __init__(self, data : bytes):
         self.__rawData = data
-        reader = BytesReader(reader)
+        reader = BytesReader(data)
 
         self.__cookie = reader.assertRead(b'PCDFEB09\x00')
 

--- a/extract_msg/structures/report_tag.py
+++ b/extract_msg/structures/report_tag.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from ._helpers import BytesReader
-from .entry_id import EntryID
+from .entry_id import EntryID, FolderEntryID, MessageEntryID, StoreObjectEntryID
 
 
 class ReportTag:
@@ -18,25 +18,25 @@ class ReportTag:
         self.__version = reader.readUnsignedInt()
         entrySize = reader.readInt()
         if entrySize:
-            self.__storeEntryID = EntryID.autoCreate(reader.read(entrySize))
+            self.__storeEntryID = StoreObjectEntryID(reader.read(entrySize))
         else:
             self.__storeEntryID = None
 
         entrySize = reader.readInt()
         if entrySize:
-            self.__folderEntryID = EntryID.autoCreate(reader.read(entrySize))
+            self.__folderEntryID = FolderEntryID(reader.read(entrySize))
         else:
             self.__folderEntryID = None
 
         entrySize = reader.readInt()
         if entrySize:
-            self.__messageEntryID = EntryID.autoCreate(reader.read(entrySize))
+            self.__messageEntryID = MessageEntryID(reader.read(entrySize))
         else:
             self.__messageEntryID = None
 
         entrySize = reader.readInt()
         if entrySize:
-            self.__searchFolderEntryID = EntryID.autoCreate(reader.read(entrySize))
+            self.__searchFolderEntryID = FolderEntryID(reader.read(entrySize))
         else:
             self.__searchFolderEntryID = None
 

--- a/extract_msg/task.py
+++ b/extract_msg/task.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 
-from typing import Set
+from typing import Optional, Set
 
 from . import constants
 from .enums import TaskAcceptance, TaskHistory, TaskMode, TaskMultipleRecipients, TaskOwnership, TaskState, TaskStatus
@@ -74,7 +74,7 @@ class Task(MessageBase):
         }
 
     @property
-    def percentComplete(self) -> float:
+    def percentComplete(self) -> Optional[float]:
         """
         Indicates whether a time-flagged Message object is complete. Returns a
         percentage in decimal form. 1.0 indicates it is complete.
@@ -82,7 +82,7 @@ class Task(MessageBase):
         return self._ensureSetNamed('_percentComplete', '8102', constants.PSETID_TASK)
 
     @property
-    def taskAcceptanceState(self) -> TaskAcceptance:
+    def taskAcceptanceState(self) -> Optional[TaskAcceptance]:
         """
         Indicates the acceptance state of the task.
         """
@@ -94,10 +94,10 @@ class Task(MessageBase):
         Indicates whether a task assignee has replied to a tesk request for this
         task object. Does not indicate if it was accepted or rejected.
         """
-        return self._ensureSetNamed('_taskAccepted', '8108', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskAccepted', '8108', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
-    def taskActualEffort(self) -> int:
+    def taskActualEffort(self) -> Optional[int]:
         """
         Indicates the number of minutes that the user actually spent working on
         a task.
@@ -105,14 +105,14 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskActualEffort', '8110', constants.PSETID_TASK)
 
     @property
-    def taskAssigner(self) -> str:
+    def taskAssigner(self) -> Optional[str]:
         """
         Specifies the name of the user that last assigned the task.
         """
         return self._ensureSetNamed('_taskAssigner', '8121', constants.PSETID_TASK)
 
     @property
-    def taskAssigners(self) -> bytes:
+    def taskAssigners(self) -> Optional[bytes]:
         """
         A stack of entries, each representing a task assigner. The most recent
         task assigner (that is, the top) appears at the bottom.
@@ -126,17 +126,17 @@ class Task(MessageBase):
         """
         Indicates if the task is complete.
         """
-        return self._ensureSetNamed('_taskComplete', '811C', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskComplete', '811C', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
-    def taskCustomFlags(self) -> int:
+    def taskCustomFlags(self) -> Optional[int]:
         """
         Custom flags set on the task.
         """
         return self._ensureSetNamed('_taskCustomFlags', '8139', constants.PSETID_TASK)
 
     @property
-    def taskDateCompleted(self) -> datetime.datetime:
+    def taskDateCompleted(self) -> Optional[datetime.datetime]:
         """
         The date when the user completed work on the task.
         """
@@ -149,10 +149,10 @@ class Task(MessageBase):
         False on a new Task object and True when the client generates the last
         recurring task.
         """
-        return self._ensureSetNamed('_taskDeadOccurrence', '8109', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskDeadOccurrence', '8109', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
-    def taskDueDate(self) -> datetime.datetime:
+    def taskDueDate(self) -> Optional[datetime.datetime]:
         """
         Specifies the date by which the user expects work on the task to be
         complete.
@@ -160,7 +160,7 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskDueDate', '8105', constants.PSETID_TASK)
 
     @property
-    def taskEstimatedEffort(self) -> int:
+    def taskEstimatedEffort(self) -> Optional[int]:
         """
         Indicates the number of minutes that the user expects to work on a task.
         """
@@ -173,24 +173,24 @@ class Task(MessageBase):
         the current user or user agent instead of by the processing of a task
         request.
         """
-        return self._ensureSetNamed('_taskFCreator', '811E', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskFCreator', '811E', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
     def taskFFixOffline(self) -> bool:
         """
         Indicates whether the value of the taskOwner property is correct.
         """
-        return self._ensureSetNamed('taskFFixOffline', '812C', constants.PSETID_TASK)
+        return self._ensureSetNamed('taskFFixOffline', '812C', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
     def taskFRecurring(self) -> bool:
         """
         Indicates whether the task includes a recurrence pattern.
         """
-        return self._ensureSetNamed('_taskFRecurring', '8126', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskFRecurring', '8126', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
-    def taskGlobalID(self) -> bytes:
+    def taskGlobalID(self) -> Optional[bytes]:
         """
         Specifies a unique GUID for this task, used to locate an existing task
         upon receipt of a task response or task update.
@@ -198,14 +198,14 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskGlobalID', '8519', constants.PSETID_COMMON)
 
     @property
-    def taskHistory(self) -> TaskHistory:
+    def taskHistory(self) -> Optional[TaskHistory]:
         """
         Indicates the type of change that was last made to the Task object.
         """
         return self._ensureSetNamed('_taskHistory', '811A', constants.PSETID_TASK, overrideClass = TaskHistory)
 
     @property
-    def taskLastDelegate(self) -> str:
+    def taskLastDelegate(self) -> Optional[str]:
         """
         Contains the name of the user who most recently assigned the task, or
         the user to whom it was most recently assigned.
@@ -213,14 +213,14 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskLastDelegate', '8125', constants.PSETID_TASK)
 
     @property
-    def taskLastUpdate(self) -> datetime.datetime:
+    def taskLastUpdate(self) -> Optional[datetime.datetime]:
         """
         The date and time of the most recent change made to the task object.
         """
         return self._ensureSetNamed('_taskLastUpdate', '8115', constants.PSETID_TASK)
 
     @property
-    def taskLastUser(self) -> str:
+    def taskLastUser(self) -> Optional[str]:
         """
         Contains the name of the most recent user to have been the owner of the
         task.
@@ -228,14 +228,14 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskLastUser', '8122', constants.PSETID_TASK)
 
     @property
-    def taskMode(self) -> TaskMode:
+    def taskMode(self) -> Optional[TaskMode]:
         """
         Used in a task communication. Should be 0 (UNASSIGNED) on task objects.
         """
         return self._ensureSetNamed('_taskMode', '8518', constants.PSETID_COMMON, overrideClass = TaskMode)
 
     @property
-    def taskMultipleRecipients(self) -> Set[TaskMultipleRecipients]:
+    def taskMultipleRecipients(self) -> Optional[Set[TaskMultipleRecipients]]:
         """
         Returns a set of flags that specify optimization hints about the
         recipients of a Task object.
@@ -243,7 +243,7 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskMultipleRecipients', '8120', constants.PSETID_TASK, overrideClass = TaskMultipleRecipients.fromBits)
 
     @property
-    def taskNoCompute(self) -> bool:
+    def taskNoCompute(self) -> Optional[bool]:
         """
         This value is not used and has no impact on a Task, but is provided for
         completeness.
@@ -251,28 +251,28 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskNoCompute', '8124', constants.PSETID_TASK)
 
     @property
-    def taskOrdinal(self) -> int:
+    def taskOrdinal(self) -> Optional[int]:
         """
         Specifies a number that aids custom sorting of Task objects.
         """
         return self._ensureSetNamed('_taskOrdinal', '8123', constants.PSETID_TASK, overrideClass = unsignedToSignedInt)
 
     @property
-    def taskOwner(self) -> str:
+    def taskOwner(self) -> Optional[str]:
         """
         Contains the name of the owner of the task.
         """
         return self._ensureSetNamed('_taskOwner', '811F', constants.PSETID_TASK)
 
     @property
-    def taskOwnership(self) -> TaskOwnership:
+    def taskOwnership(self) -> Optional[TaskOwnership]:
         """
         Contains the name of the owner of the task.
         """
         return self._ensureSetNamed('_taskOwnership', '8129', constants.PSETID_TASK, overrideClass = TaskOwnership)
 
     @property
-    def taskRecurrence(self) -> RecurrencePattern:
+    def taskRecurrence(self) -> Optional[RecurrencePattern]:
         """
         Contains a RecurrencePattern structure that provides information about
         recurring tasks.
@@ -284,10 +284,10 @@ class Task(MessageBase):
         """
         Indicates whether future recurring tasks need reminders.
         """
-        return self._ensureSetNamed('_taskResetReminder', '8107', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskResetReminder', '8107', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
-    def taskRole(self) -> str:
+    def taskRole(self) -> Optional[str]:
         """
         This value is not used and has no impact on a Task, but is provided for
         completeness.
@@ -295,21 +295,21 @@ class Task(MessageBase):
         return self._ensureSetNamed('_taskRole', '8127', constants.PSETID_TASK)
 
     @property
-    def taskStartDate(self) -> datetime.datetime:
+    def taskStartDate(self) -> Optional[datetime.datetime]:
         """
         Specifies the date on which the user expects work on the task to begin.
         """
         return self._ensureSetNamed('_taskStartDate', '8104', constants.PSETID_TASK)
 
     @property
-    def taskState(self) -> TaskState:
+    def taskState(self) -> Optional[TaskState]:
         """
         Indicates the current assignment state of the Task object.
         """
         return self._ensureSetNamed('_taskState', '8113', constants.PSETID_TASK, overrideClass = TaskState)
 
     @property
-    def taskStatus(self) -> TaskStatus:
+    def taskStatus(self) -> Optional[TaskStatus]:
         """
         The completion status of a task.
         """
@@ -321,7 +321,7 @@ class Task(MessageBase):
         Indicates whether the task assignee has been requested to send an email
         message upon completion of the assigned task.
         """
-        return self._ensureSetNamed('_taskStatusOnComplete', '8119', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskStatusOnComplete', '8119', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
     def taskUpdates(self) -> bool:
@@ -329,17 +329,17 @@ class Task(MessageBase):
         Indicates whether the task assignee has been requested to send a task
         update when the assigned Task object changes.
         """
-        return self._ensureSetNamed('_taskUpdates', '811B', constants.PSETID_TASK)
+        return self._ensureSetNamed('_taskUpdates', '811B', constants.PSETID_TASK, overrideClass = bool, preserveNone = False)
 
     @property
-    def taskVersion(self) -> int:
+    def taskVersion(self) -> Optional[int]:
         """
         Indicates which copy is the latest update of a Task object.
         """
         return self._ensureSetNamed('_taskVersion', '8112', constants.PSETID_TASK)
 
     @property
-    def teamTask(self) -> bool:
+    def teamTask(self) -> Optional[bool]:
         """
         This value is not used and has no impact on a Task, but is provided for
         completeness.

--- a/extract_msg/task_request.py
+++ b/extract_msg/task_request.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing import Optional
+
 from . import constants
 from .enums import TaskMode, TaskRequestType
 from .exceptions import StandardViolationError
@@ -52,10 +54,10 @@ class TaskRequest(MessageBase):
         Indicates whether a client has already processed a received task
         communication.
         """
-        return self._ensureSetProperty('_processed', '7D01000B')
+        return self._ensureSetProperty('_processed', '7D01000B', overrideClass = bool, preserveNone = False)
 
     @property
-    def taskMode(self) -> TaskMode:
+    def taskMode(self) -> Optional[TaskMode]:
         """
         The assignment status of the embedded Task object.
         """

--- a/extract_msg/validation.py
+++ b/extract_msg/validation.py
@@ -25,8 +25,8 @@ def getStringDetails(instance, stream):
 
 def stringFE(instance):
     temp = '001E'
-    if instance.mainProperties.has_key('340D0003'):
-        temp = '001F' if instance.mainProperties['340D0003'].value & 0x40000 else '001E'
+    if instance.props.has_key('340D0003'):
+        temp = '001F' if instance.props['340D0003'].value & 0x40000 else '001E'
     tempnot = '001F' if temp == '001E' else '001E'
     confirmation = all(not x[-1].endswith(tempnot) for x in instance.listDir())
     if confirmation:


### PR DESCRIPTION
**v0.36.0**
* Improved type hints to tell when a function may not return anything.
* Added support for the `reportTag` property to `MessageBase`. I noticed this was one of the properties for `IPM.Outlook.Recall` so I decided to implement it. I'll work on ensuring all of `[MS-OXOMSG]` and `[MS-OXCMSG]` are implemented at a later date, including splitting off `REPORT` into it's own class, because it is it's own class.
* Fixed a few minor issues in some properties. Mostly some `bool` returning properties should have been returning False when they were not found instead of None. Ones that may return None are specifically typed as optional in the source code. Unfortunately using the `help` command doesn't seem to show the return type for properties for me at least on Python 3.9 and below.
* Fixed `Attachment.save` returning a `pathlib.Path` object instead of a `str` after the conversion to `pathlib`.
* Added code to allow `pathlib` objects in `utils.openMsgBulk`. It uses `glob.glob` which *cannot* take a `pathlib` object.
* Removed `PermanentEntryID` from `EntryID.autoCreate`. It shares a provider ID with `AddressBookEntryID`, and as such would never generate from it anyways. If you specifically need a `PermanentEntryID` you will have to instantiate it manually. Additionally, the entry has been removed from `enums.EntryIDType`.
* Fixed the GUIDs for some of the EntryID structures being returned as bytes instead of a standard GUID string. This is considered a breaking change and is the reason for the full version increase.
* Improved consistency of properties (the Python kind, not the MSG kind) so that properties for the raw data used to create an instance will all use the same name. Not all classes have this, but the ones that do will now all use `rawData` as the property name.
* Fixed the properties header being read in a way that actually swapped the values in it.
* Modified `MSGFile` to use the same name for Properties instances as all other classes. `MSGFile.mainProperties` will currently raise a `DeprecationWarning` instead of outright failing to help ease the transition. Use `MSGFile.props` instead.