### PR TITLE
Version 0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.37.0**
+* Added new option to allow messages with `NotImplementedError` attachments to at least save everything not related to them. From the command line this would be `--skip-not-implemented` or `--skip-ni`. From the save function, this would be the `skipNotImplemented` option.
+
 **v0.36.0**
 * Improved type hints to tell when a function may not return anything.
 * Added support for the `reportTag` property to `MessageBase`. I noticed this was one of the properties for `IPM.Outlook.Recall` so I decided to implement it. I'll work on ensuring all of `[MS-OXOMSG]` and `[MS-OXCMSG]` are implemented at a later date, including splitting off `REPORT` into it's own class, because it is it's own class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-**v0.37.0**
+**v0.36.1**
+* [[TeamMsgExtractor #283](https://github.com/TeamMsgExtractor/msg-extractor/issues/283)] Added file for typing recognition.
 * Added new option to allow messages with `NotImplementedError` attachments to at least save everything not related to them. From the command line this would be `--skip-not-implemented` or `--skip-ni`. From the save function, this would be the `skipNotImplemented` option.
 
 **v0.36.0**

--- a/README.rst
+++ b/README.rst
@@ -226,8 +226,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.36.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.37.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.37.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/README.rst
+++ b/README.rst
@@ -226,8 +226,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.37.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.37.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.1-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.36.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-07-16'
-__version__ = '0.37.0'
+__date__ = '2022-07-20'
+__version__ = '0.36.1'
 
 import logging
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-07-15'
-__version__ = '0.36.0'
+__date__ = '2022-07-16'
+__version__ = '0.37.0'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -5,6 +5,7 @@ import traceback
 import zipfile
 
 from extract_msg import __doc__, utils
+from extract_msg.enums import AttachErrorBehavior
 
 
 def main() -> None:
@@ -67,6 +68,7 @@ def main() -> None:
             'preparedHtml': args.preparedHtml,
             'rtf': args.rtf,
             'skipEmbedded': args.skipEmbedded,
+            'skipNotImplemented': args.skipNotImplemented,
             'useMsgFilename': args.useFilename,
             'wkOptions': args.wkOptions,
             'wkPath': args.wkPath,
@@ -76,6 +78,11 @@ def main() -> None:
         openKwargs = {
             'ignoreRtfDeErrors': args.ignoreRtfDeErrors,
         }
+
+        # If we are skipping the NotImplementedError attachments, we need to
+        # suppress the error.
+        if args.skipNotImplemented:
+            openKwargs['attachmentErrorBehavior'] = AttachErrorBehavior.NOT_IMPLEMENTED
 
         def strSanitize(inp):
             """

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -264,6 +264,16 @@ class UnsupportedAttachment(AttachmentBase):
     An attachment whose type is not currently supported.
     """
 
+    def save(self, **kwargs) -> None:
+        """
+        Raises a NotImplementedError unless :param skipNotImplemented: is set to
+        True. If it is, returns None to signify the attachment was skipped. This
+        allows for the easy implementation of the option to skip this type of
+        attachment.
+        """
+        if not kwargs.get('skipNotImplemented', False):
+            raise NotImplementedError('Unsupported attachments cannot be saved.')
+
     @property
     def type(self) -> AttachmentType:
         """

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -581,6 +581,7 @@ class MSGFile:
                 try:
                     self._attachments.append(self.attachmentClass(self, attachmentDir))
                 except (NotImplementedError, UnrecognizedMSGTypeError) as e:
+                    print("Hello")
                     if self.attachmentErrorBehavior != AttachErrorBehavior.THROW:
                         logger.error(f'Error processing attachment at {attachmentDir}')
                         logger.exception(e)

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -9,6 +9,7 @@ import zipfile
 import olefile
 
 from typing import List, Optional, Set, Union
+from warnings import warn
 
 from . import constants
 from .attachment import Attachment, BrokenAttachment, UnsupportedAttachment
@@ -705,9 +706,8 @@ class MSGFile:
 
     @property
     def mainProperties(self) -> Properties:
-        warnings.warn('`MSGFile.mainProperties` is deprecated and will soon' + \
-                      ' be removed. Please use `MSGFile.props` instead.',
-                      warnings.DeprecationWarning)
+        warn('`MSGFile.mainProperties` is deprecated and will soon be ' + \
+             'removed. Please use `MSGFile.props` instead.', DeprecationWarning)
         return self.props
 
     @property

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -14,15 +14,15 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def createProp(string) -> 'PropBase':
-    temp = constants.ST2.unpack(string)[0]
+def createProp(data : bytes) -> 'PropBase':
+    temp = constants.ST2.unpack(data)[0]
     if temp in constants.FIXED_LENGTH_PROPS:
-        return FixedLengthProp(string)
+        return FixedLengthProp(data)
     else:
         if temp not in constants.VARIABLE_LENGTH_PROPS:
             # DEBUG
             logger.warning(f'Unknown property type: {properHex(temp)}')
-        return VariableLengthProp(string)
+        return VariableLengthProp(data)
 
 
 class PropBase:
@@ -32,8 +32,8 @@ class PropBase:
 
     def __init__(self, data : bytes):
         self.__rawData = data
-        self.__name = properHex(string[3::-1]).upper()
-        self.__type, self.__flags = constants.ST2.unpack(string)
+        self.__name = properHex(data[3::-1]).upper()
+        self.__type, self.__flags = constants.ST2.unpack(data)
         self.__fm = self.__flags & 1 == 1
         self.__fr = self.__flags & 2 == 2
         self.__fw = self.__flags & 4 == 4

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -301,9 +301,12 @@ def getCommandArgs(args) -> argparse.Namespace:
     # --no-folders
     parser.add_argument('--no-folders', dest='noFolders', action='store_true',
                         help='Stores everything in the location specified by --out. Requires --attachments-only and is incompatible with --out-name.')
-
-    parser.add_argument('--skip-embedded', dest = 'skipEmbedded', action='store_true',
+    # --skip-embedded
+    parser.add_argument('--skip-embedded', dest='skipEmbedded', action='store_true',
                         help='Skips all embedded MSG files when saving attachments.')
+    # --skip-not-implemented
+    parser.add_argument('--skip-not-implemented', '--skip-ni', dest='skipNotImplemented', action='store_true',
+                        help='Skips any attachments that are not implemented, allowing saving of the rest of the message.')
     # --out-name NAME
     inputFormat.add_argument('--out-name', dest='outName',
                         help='Name to be used with saving the file output. Cannot be used if you are saving more than one file.')


### PR DESCRIPTION
**v0.36.1**
* [[TeamMsgExtractor #283](https://github.com/TeamMsgExtractor/msg-extractor/issues/283)] Added file for typing recognition.
* Added new option to allow messages with `NotImplementedError` attachments to at least save everything not related to them. From the command line this would be `--skip-not-implemented` or `--skip-ni`. From the save function, this would be the `skipNotImplemented` option.