### PR TITLE
Add --save-header argument to enable saving header

### DIFF
--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -67,6 +67,7 @@ def main() -> None:
             'pdf': args.pdf,
             'preparedHtml': args.preparedHtml,
             'rtf': args.rtf,
+            'saveHeader': args.saveHeader,
             'skipBodyNotFound': args.skipBodyNotFound,
             'skipEmbedded': args.skipEmbedded,
             'skipNotImplemented': args.skipNotImplemented,

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -664,6 +664,8 @@ class MessageBase(MSGFile):
         to :param zip:. If :param zip: is set, :param customPath: will refer to
         a location inside the zip file.
 
+        :param saveHeader: Turns on saving the header as separate file when
+            set.
         :param attachmentsOnly: Turns off saving the body and only saves the
             attachments when set.
         :param skipAttachments: Turns off saving attachments.

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -298,6 +298,9 @@ def getCommandArgs(args) -> argparse.Namespace:
     # --zip
     parser.add_argument('--zip', dest='zip',
                         help='Path to use for saving to a zip file.')
+    # --save-header
+    parser.add_argument('--save-header', dest='saveHeader', action='store_true',
+                        help='Store the header in a separate file.')
     # --attachments-only
     outFormat.add_argument('--attachments-only', dest='attachmentsOnly', action='store_true',
                            help='Specify to only save attachments from an msg file.')


### PR DESCRIPTION
- [X] Issue #16
- [ ] Have you listed any changes to install or build dependencies?
- [X] Ensured your changes are compatible with Python 2.7 (ONLY FOR v0.29).
- [ ] Have you updated the [CHANGELOG](CHANGELOG.md) with details of changes to the codebase, this includes new functionality, deprecated features, or any other material changes.
- [ ] If necessary, have you bumped the version number? We will usually do this for you.
- [ ] Have you included py.test tests with your pull request. (Not yet necessary)
- [X] Ensured your code is as close to PEP 8 compliant as possible?
- [X] Ensured your pull request is to the `next-release` branch (or `v0.29` if applicable)?

I've seen that the `save()` function supports an undocumented `saveHeader` keyword argument and because I find it very useful (e.g. for analyzing the origin and other metadata of an email) I've added the command line argument `--save-header` to enable this option and added documentation to this argument.

As this function is already available, no additional install or build dependencies are needed.