### PR TITLE
Version 0.36.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 **v0.36.4**
 * [[TeamMsgExtractor #291](https://github.com/TeamMsgExtractor/msg-extractor/issues/291)] Fixed typo in `MSGFile.saveRaw` that may have existed for a significant amount of time. It was using the wrong function (same name, but with different capitalization) but was hidden until `MSGFile` stopped being derived from `OleFileIO`.
-* [[TeamMsgExtractor #291](https://github.com/TeamMsgExtractor/msg-extractor/issues/291)] Adjusted subprocess call to `wkhtmltopdf` to help user having issues with `subprocess.Popen` using a list for the arguments. `wkhtmltopdf` acted like it was given no arguments at all.
 * Added logging code to `MessageBase.getSavePdfBody` to log the list that is going to be used to run `wkhtmltopdf`. This is mainly for debugging purposes, to allow users to potentially see why their arguments may be failing.
 * Updating funding information on GitHub and the `README` with more ways to support the module's development.
 * Fixed one of the exceptions in `MessageBase.getSavePdfBody` not using an fstring which caused it to omit information.
+* Changed the way `wkhtmltopdf` is called to patch a possible security vulnerability. This also seems to have fixed [[TeamMsgExtractor #291](https://github.com/TeamMsgExtractor/msg-extractor/issues/291)].
 
 **v0.36.3**
 * Added an option to skip the body if it could not be found, rather than throwing an error. This will cause no file to be made for it in the event no valid body exists. For the save functions, this option is `skipBodyNotFound` and from the command line the option is `--skip-body-not-found`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.36.5**
+* Documented and exposed to the command line the ability to save the headers to it's own file when saving the msg file. Thanks to martin-mueller-cemas on GitHub for fixing this (and telling me I can switch the branch a pull request points to). I don't know when I added the code to allow the user to do it, but somehow it was never documented and never exposed to the command line.
+
 **v0.36.4**
 * [[TeamMsgExtractor #291](https://github.com/TeamMsgExtractor/msg-extractor/issues/291)] Fixed typo in `MSGFile.saveRaw` that may have existed for a significant amount of time. It was using the wrong function (same name, but with different capitalization) but was hidden until `MSGFile` stopped being derived from `OleFileIO`.
 * Added logging code to `MessageBase.getSavePdfBody` to log the list that is going to be used to run `wkhtmltopdf`. This is mainly for debugging purposes, to allow users to potentially see why their arguments may be failing.

--- a/README.rst
+++ b/README.rst
@@ -230,8 +230,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.4-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.36.4/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.5-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.36.5/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/README.rst
+++ b/README.rst
@@ -231,7 +231,7 @@ your access to the newest major version of extract-msg.
    :target: LICENSE.txt
 
 .. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.4-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.36.5/
+   :target: https://pypi.org/project/extract-msg/0.36.4/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-09-29'
-__version__ = '0.36.4'
+__date__ = '2022-11-05'
+__version__ = '0.36.5'
 
 import logging
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,7 +27,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-09-16'
+__date__ = '2022-09-29'
 __version__ = '0.36.4'
 
 import logging

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -67,6 +67,7 @@ def main() -> None:
             'pdf': args.pdf,
             'preparedHtml': args.preparedHtml,
             'rtf': args.rtf,
+            'saveHeader': args.saveHeader,
             'skipBodyNotFound': args.skipBodyNotFound,
             'skipEmbedded': args.skipEmbedded,
             'skipNotImplemented': args.skipNotImplemented,

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -664,10 +664,10 @@ class MessageBase(MSGFile):
         to :param zip:. If :param zip: is set, :param customPath: will refer to
         a location inside the zip file.
 
-        :param saveHeader: Turns on saving the header as separate file when
-            set.
         :param attachmentsOnly: Turns off saving the body and only saves the
             attachments when set.
+        :param saveHeader: Turns on saving the header as a separate file when
+        set.
         :param skipAttachments: Turns off saving attachments.
         :param skipBodyNotFound: Suppresses errors if no valid body could be
             found, simply skipping the step of saving the body.

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -389,11 +389,6 @@ class MessageBase(MSGFile):
         if not all(isinstance(option, (str, bytes)) for option in parsedWkOptions):
             raise TypeError(':param wkOptions: must be an iterable of strings and bytes.')
 
-        # TeamMsgExtractor#291 showed a user who had issues with the list of
-        # args to Popen. I couldn't replicate it, but for some reason making it
-        # a string fixed the issue.
-        #processArgs = ' '.join(f'"{x}"' if ' ' in x and x[0] != '"' else x
-        #                      for x in map(os.fsdecode, (wkPath, *parsedWkOptions, '-', '-')))
         processArgs = [wkPath, *parsedWkOptions, '-', '-']
         # Log the arguments.
         logger.info(f'Converting to PDF with the following arguments: {processArgs}')

--- a/extract_msg/message_base.py
+++ b/extract_msg/message_base.py
@@ -664,6 +664,8 @@ class MessageBase(MSGFile):
         to :param zip:. If :param zip: is set, :param customPath: will refer to
         a location inside the zip file.
 
+        :param saveHeader: Turns on saving the header as separate file when
+            set.
         :param attachmentsOnly: Turns off saving the body and only saves the
             attachments when set.
         :param skipAttachments: Turns off saving attachments.

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -298,6 +298,9 @@ def getCommandArgs(args) -> argparse.Namespace:
     # --zip
     parser.add_argument('--zip', dest='zip',
                         help='Path to use for saving to a zip file.')
+    # --save-header
+    parser.add_argument('--save-header', dest='saveHeader', action='store_true',
+                        help='Store the header in a separate file.')
     # --attachments-only
     outFormat.add_argument('--attachments-only', dest='attachmentsOnly', action='store_true',
                            help='Specify to only save attachments from an msg file.')


### PR DESCRIPTION
**v0.36.5**
* Documented and exposed to the command line the ability to save the headers to it's own file when saving the msg file. Thanks to martin-mueller-cemas on GitHub for fixing this (and telling me I can switch the branch a pull request points to). I don't know when I added the code to allow the user to do it, but somehow it was never documented and never exposed to the command line.