### PR TITLE
Version 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v0.37.0**
+* [[TeamMsgExtractor #303](https://github.com/TeamMsgExtractor/msg-extractor/issues/303)] Renamed internal variable that wasn't changed when the other instances or it were renamed.
+* [[TeamMsgExtractor #302](https://github.com/TeamMsgExtractor/msg-extractor/issues/302)] Fixed properties missing (a fatal MSG error) raising an unclear exception. It now uses `InvalidFileFormatError`.
+* Updated `README` to contain documentation on command line option added in previous version.
+* Removed `MSGFile.mainProperties` after deprecating it in v0.36.0.
+* Added new `Properties` `Intelligence` type: `ERROR`. This type is used when a properties instance is created but has something wrong with it that is not necessarily fatal. Currently the only thing that will cause it is the properties stream being 0 bytes.
+
 **v0.36.5**
 * Documented and exposed to the command line the ability to save the headers to it's own file when saving the msg file. Thanks to martin-mueller-cemas on GitHub for fixing this (and telling me I can switch the branch a pull request points to). I don't know when I added the code to allow the user to do it, but somehow it was never documented and never exposed to the command line.
 

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ refer to the usage information provided from the program's help dialog:
       --allow-fallback      Tells the program to fallback to a different save type if the selected one is not possible.
       --skip-body-not-found Skips saving the body if the body cannot be found, rather than throwing an error.
       --zip ZIP             Path to use for saving to a zip file.
+      --save-header         Store the header in a separate file.
       --attachments-only    Specify to only save attachments from an msg file.
       --no-folders          When used with --attachments-only, stores everything in the location specified by --out. Incompatible with --out-name.
       --skip-embedded       Skips all embedded MSG files when saving attachments.
@@ -230,8 +231,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.36.5-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.36.5/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.37.0 -blue.svg
+   :target: https://pypi.org/project/extract-msg/0.37.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-11-05'
-__version__ = '0.36.5'
+__date__ = '2022-11-17'
+__version__ = '0.37.0'
 
 import logging
 

--- a/extract_msg/enums.py
+++ b/extract_msg/enums.py
@@ -1077,6 +1077,7 @@ class Importance(enum.Enum):
 
 
 class Intelligence(enum.Enum):
+    ERROR = -1
     DUMB = 0
     SMART = 1
 

--- a/extract_msg/properties.py
+++ b/extract_msg/properties.py
@@ -20,7 +20,9 @@ class Properties:
     Parser for msg properties files.
     """
 
-    def __init__(self, data : bytes, type : Optional[PropertiesType] = None, skip : Optional[int] = None):
+    def __init__(self, data : bytes, _type : Optional[PropertiesType] = None, skip : Optional[int] = None):
+        if not isinstance(data, bytes):
+            raise TypeError(':param data: MUST be bytes.')
         self.__rawData = data
         self.__pos = 0
         self.__len = len(data)
@@ -29,31 +31,34 @@ class Properties:
         self.__nrid = None
         self.__ac = None
         self.__rc = None
-        if type is not None:
-            type = PropertiesType(type)
-            self.__intel = Intelligence.SMART
-            if type == PropertiesType.MESSAGE:
-                skip = 32
-                self.__nrid, self.__naid, self.__rc, self.__ac = constants.ST1.unpack(self.__rawData[:24])
-            elif type == PropertiesType.MESSAGE_EMBED:
-                skip = 24
-                self.__nrid, self.__naid, self.__rc, self.__ac = constants.ST1.unpack(self.__rawData[:24])
-            else:
-                skip = 8
+        # Handle an empty properties stream.
+        if self.__len == 0:
+            self.__intel = Intelligence.ERROR
+            skip = 0
+        elif _type is not None:
+                _type = PropertiesType(_type)
+                self.__intel = Intelligence.SMART
+                if _type == PropertiesType.MESSAGE:
+                    skip = 32
+                    self.__nrid, self.__naid, self.__rc, self.__ac = constants.ST1.unpack(self.__rawData[:24])
+                elif _type == PropertiesType.MESSAGE_EMBED:
+                    skip = 24
+                    self.__nrid, self.__naid, self.__rc, self.__ac = constants.ST1.unpack(self.__rawData[:24])
+                else:
+                    skip = 8
         else:
             self.__intel = Intelligence.DUMB
             if skip is None:
-                # This section of the skip handling is not very good.
-                # While it does work, it is likely to create extra
-                # properties that are created from the properties file's
-                # header data. While that won't actually mess anything
-                # up, it is far from ideal. Basically, this is the dumb
-                # skip length calculation. Preferably, we want the type
-                # to have been specified so all of the additional fields
-                # will have been filled out
-                skip = self.__len % 16
-                if skip == 0:
-                    skip = 32
+                # This section of the skip handling is not very good. While it
+                # does work, it is likely to create extra properties that are
+                # created from the properties file's header data. While that
+                # won't actually mess anything up, it is far from ideal.
+                # Basically, this is the dumb skip length calculation.
+                # Preferably, we want the type to have been specified so all of
+                # the additional fields will have been filled out.
+                #
+                # If the skip would end up at 0, set it to 32.
+                skip = (self.__len % 16) or 32
         streams = divide(self.__rawData[skip:], 16)
         for st in streams:
             if len(st) == 16:
@@ -95,7 +100,7 @@ class Properties:
             logger.debug(self.__props)
             return default
 
-    def has_key(self, key):
+    def has_key(self, key) -> bool:
         """
         Checks if :param key: is a key in the properties dictionary.
         """
@@ -107,7 +112,7 @@ class Properties:
     def keys(self):
         return self.__props.keys()
 
-    def pprintKeys(self):
+    def pprintKeys(self) -> None:
         """
         Uses the pprint function on a sorted list of keys.
         """

--- a/extract_msg/properties.py
+++ b/extract_msg/properties.py
@@ -91,7 +91,7 @@ class Properties:
         except KeyError:
             # DEBUG
             logger.debug('KeyError exception.')
-            logger.debug(properHex(self.__stream))
+            logger.debug(properHex(self.__rawData))
             logger.debug(self.__props)
             return default
 


### PR DESCRIPTION
**v0.37.0**
* [[TeamMsgExtractor #303](https://github.com/TeamMsgExtractor/msg-extractor/issues/303)] Renamed internal variable that wasn't changed when the other instances or it were renamed.
* [[TeamMsgExtractor #302](https://github.com/TeamMsgExtractor/msg-extractor/issues/302)] Fixed properties missing (a fatal MSG error) raising an unclear exception. It now uses `InvalidFileFormatError`.
* Updated `README` to contain documentation on command line option added in previous version.
* Removed `MSGFile.mainProperties` after deprecating it in v0.36.0.
* Added new `Properties` `Intelligence` type: `ERROR`. This type is used when a properties instance is created but has something wrong with it that is not necessarily fatal. Currently the only thing that will cause it is the properties stream being 0 bytes.