### PR TITLE
Version 0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v0.37.1**
+* Added option to save function (including `MSGFile.saveAttachments`) to skip any attachments marked as hidden. This can also be done from the command line with `--skip-hidden`.
+* Fixed an issue that could cause an `MSGFile` to be included in the attachment names instead of just strings.
+* Fixed up several comments.
+* Fixed bug that would cause spaces at the end of the subject or filename to break the module.
+
 **v0.37.0**
 * [[TeamMsgExtractor #303](https://github.com/TeamMsgExtractor/msg-extractor/issues/303)] Renamed internal variable that wasn't changed when the other instances or it were renamed.
 * [[TeamMsgExtractor #302](https://github.com/TeamMsgExtractor/msg-extractor/issues/302)] Fixed properties missing (a fatal MSG error) raising an unclear exception. It now uses `InvalidFileFormatError`.

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ refer to the usage information provided from the program's help dialog:
       --zip ZIP             Path to use for saving to a zip file.
       --save-header         Store the header in a separate file.
       --attachments-only    Specify to only save attachments from an msg file.
+      --skip-hidden         Skips any attachment marked as hidden (usually ones embedded in the body).
       --no-folders          When used with --attachments-only, stores everything in the location specified by --out. Incompatible with --out-name.
       --skip-embedded       Skips all embedded MSG files when saving attachments.
       --out-name OUTNAME    Name to be used with saving the file output. Cannot be used if you are saving more than one file.

--- a/README.rst
+++ b/README.rst
@@ -231,8 +231,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.37.0 -blue.svg
-   :target: https://pypi.org/project/extract-msg/0.37.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.37.1 -blue.svg
+   :target: https://pypi.org/project/extract-msg/0.37.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-11-17'
-__version__ = '0.37.0'
+__date__ = '2022-11-27'
+__version__ = '0.37.1'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -70,6 +70,7 @@ def main() -> None:
             'saveHeader': args.saveHeader,
             'skipBodyNotFound': args.skipBodyNotFound,
             'skipEmbedded': args.skipEmbedded,
+            'skipHidden': args.skipHidden,
             'skipNotImplemented': args.skipNotImplemented,
             'useMsgFilename': args.useFilename,
             'wkOptions': args.wkOptions,

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -33,7 +33,7 @@ class Attachment(AttachmentBase):
         """
         super().__init__(msg, dir_)
 
-        # Get attachment data
+        # Get attachment data.
         if self.exists('__substg1.0_37010102'):
             self.__type = AttachmentType.DATA
             self.__data = self._getStream('__substg1.0_37010102')
@@ -41,13 +41,13 @@ class Attachment(AttachmentBase):
             if (self.props['37050003'].value & 0x7) != 0x5:
                 raise NotImplementedError(
                     'Current version of extract_msg does not support extraction of containers that are not embedded msg files.')
-                # TODO add implementation
+                # TODO add implementation.
             else:
                 self.__prefix = msg.prefixList + [dir_, '__substg1.0_3701000D']
                 self.__type = AttachmentType.MSG
                 self.__data = openMsg(self.msg.path, prefix = self.__prefix, parentMsg = self.msg, **self.msg.kwargs)
         elif (self.props['37050003'].value & 0x7) == 0x7:
-            # TODO Handling for special attacment type 0x7
+            # TODO Handling for special attacment type 0x7.
             self.__type = AttachmentType.WEB
             raise NotImplementedError('Attachments of type afByWebReference are not currently supported.')
         else:
@@ -67,7 +67,8 @@ class Attachment(AttachmentBase):
         customFilename = kwargs.get('customFilename')
         if customFilename:
             customFilename = str(customFilename)
-            # First we need to validate it. If there are invalid characters, this will detect it.
+            # First we need to validate it. If there are invalid characters,
+            # this will detect it.
             if constants.RE_INVALID_FILENAME_CHARACTERS.search(customFilename):
                 raise ValueError('Invalid character found in customFilename. Must not contain any of the following characters: \\/:*?"<>|')
             filename = customFilename

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -509,9 +509,14 @@ class MSGFile:
     def saveAttachments(self, **kwargs) -> None:
         """
         Saves only attachments in the same folder.
+
+        :params skipHidden: If True, skips attachments marked as hidden.
+            (Default: False)
         """
+        skipHidden = kwargs.get('skipHidden', False)
         for attachment in self.attachments:
-            attachment.save(**kwargs)
+            if not (skipHidden and attachment.hidden):
+                attachment.save(**kwargs)
 
     def saveRaw(self, path):
         # Create a 'raw' folder.

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -304,6 +304,9 @@ def getCommandArgs(args) -> argparse.Namespace:
     # --attachments-only
     outFormat.add_argument('--attachments-only', dest='attachmentsOnly', action='store_true',
                            help='Specify to only save attachments from an msg file.')
+    # --skip-hidden
+    parser.add_argument('--skip-hidden', dest='skipHidden', action='store_true',
+                        help='Skips any attachment marked as hidden (usually ones embedded in the body).')
     # --no-folders
     parser.add_argument('--no-folders', dest='noFolders', action='store_true',
                         help='Stores everything in the location specified by --out. Requires --attachments-only and is incompatible with --out-name.')
@@ -836,7 +839,7 @@ def prepareFilename(filename) -> str:
     file name.
     """
     # I would use re here, but it tested to be slightly slower than this.
-    return ''.join(i for i in filename if i not in r'\/:*?"<>|' + '\x00')
+    return ''.join(i for i in filename if i not in r'\/:*?"<>|' + '\x00').strip()
 
 
 def properHex(inp, length : int = 0) -> str:


### PR DESCRIPTION
**v0.37.1**
* Added option to save function (including `MSGFile.saveAttachments`) to skip any attachments marked as hidden. This can also be done from the command line with `--skip-hidden`.
* Fixed an issue that could cause an `MSGFile` to be included in the attachment names instead of just strings.
* Fixed up several comments.
* Fixed bug that would cause spaces at the end of the subject or filename to break the module.