### PR TITLE
Ole writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 **???***
 * Added class to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
-* Fixed minor issues with `utils.inputToMsgPath` (named from `utils.inputToMsgpath`).
+* Added function `MSGFile.export` which copies all streams and storages from an MSG file into a new file. This can "clone" an MSG file or be used for extracting an MSG file that is embedded inside of another.
+* Added hidden function to `MSGFile` for getting the `OleDirectoryEntry` for a storage or stream. This is mainly for use by the `OleWriter` class.
+* Added option `extractEmbedded` to `Attachment.save` (`--extract-embedded` on the command line) which causes embedded MSG files to be extracted instead of running their save methods.
+* Fixed minor issues with `utils.inputToMsgPath` (renamed from `utils.inputToMsgpath`).
 * Renamed `utils.msgpathToString` to `utils.msgPathToString`.
 
 **v0.37.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**???***
+* Added class to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
+* Added function `MSGFile.export` which copies all streams and storages from an MSG file into a new file. This can "clone" an MSG file or be used for extracting an MSG file that is embedded inside of another.
+* Added hidden function to `MSGFile` for getting the `OleDirectoryEntry` for a storage or stream. This is mainly for use by the `OleWriter` class.
+* Added option `extractEmbedded` to `Attachment.save` (`--extract-embedded` on the command line) which causes embedded MSG files to be extracted instead of running their save methods.
+* Fixed minor issues with `utils.inputToMsgPath` (renamed from `utils.inputToMsgpath`).
+* Renamed `utils.msgpathToString` to `utils.msgPathToString`.
+
 **v0.37.1**
 * Added option to save function (including `MSGFile.saveAttachments`) to skip any attachments marked as hidden. This can also be done from the command line with `--skip-hidden`.
 * Fixed an issue that could cause an `MSGFile` to be included in the attachment names instead of just strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-**???***
-* Added class to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
+**v0.38.0**
+* [[TeamMsgExtractor #117](https://github.com/TeamMsgExtractor/msg-extractor/issues/117)] Added class `OleWriter` to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
 * Added function `MSGFile.export` which copies all streams and storages from an MSG file into a new file. This can "clone" an MSG file or be used for extracting an MSG file that is embedded inside of another.
 * Added hidden function to `MSGFile` for getting the `OleDirectoryEntry` for a storage or stream. This is mainly for use by the `OleWriter` class.
 * Added option `extractEmbedded` to `Attachment.save` (`--extract-embedded` on the command line) which causes embedded MSG files to be extracted instead of running their save methods.
 * Fixed minor issues with `utils.inputToMsgPath` (renamed from `utils.inputToMsgpath`).
 * Renamed `utils.msgpathToString` to `utils.msgPathToString`.
+* Made some of the module requirements a little more strict to better version control. I'll be trying to make periodic checks for updates to the dependency packages and make sure that new versions are compatible before changing the allowed versions, while also trying to keep the requirements a bit flexible.
 
 **v0.37.1**
 * Added option to save function (including `MSGFile.saveAttachments`) to skip any attachments marked as hidden. This can also be done from the command line with `--skip-hidden`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-**???***
-* Added class to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
-* Added function `MSGFile.export` which copies all streams and storages from an MSG file into a new file. This can "clone" an MSG file or be used for extracting an MSG file that is embedded inside of another.
-* Added hidden function to `MSGFile` for getting the `OleDirectoryEntry` for a storage or stream. This is mainly for use by the `OleWriter` class.
-* Added option `extractEmbedded` to `Attachment.save` (`--extract-embedded` on the command line) which causes embedded MSG files to be extracted instead of running their save methods.
-* Fixed minor issues with `utils.inputToMsgPath` (renamed from `utils.inputToMsgpath`).
-* Renamed `utils.msgpathToString` to `utils.msgPathToString`.
-
 **v0.37.0**
 * [[TeamMsgExtractor #303](https://github.com/TeamMsgExtractor/msg-extractor/issues/303)] Renamed internal variable that wasn't changed when the other instances or it were renamed.
 * [[TeamMsgExtractor #302](https://github.com/TeamMsgExtractor/msg-extractor/issues/302)] Fixed properties missing (a fatal MSG error) raising an unclear exception. It now uses `InvalidFileFormatError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**???***
+* Added class to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
+* Fixed minor issues with `utils.inputToMsgPath` (named from `utils.inputToMsgpath`).
+* Renamed `utils.msgpathToString` to `utils.msgPathToString`.
+
 **v0.37.0**
 * [[TeamMsgExtractor #303](https://github.com/TeamMsgExtractor/msg-extractor/issues/303)] Renamed internal variable that wasn't changed when the other instances or it were renamed.
 * [[TeamMsgExtractor #302](https://github.com/TeamMsgExtractor/msg-extractor/issues/302)] Fixed properties missing (a fatal MSG error) raising an unclear exception. It now uses `InvalidFileFormatError`.

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ refer to the usage information provided from the program's help dialog:
       --skip-hidden         Skips any attachment marked as hidden (usually ones embedded in the body).
       --no-folders          When used with --attachments-only, stores everything in the location specified by --out. Incompatible with --out-name.
       --skip-embedded       Skips all embedded MSG files when saving attachments.
+      --extract-embedded    Extracts the embedded MSG files as MSG files instead of running their save functions.
       --out-name OUTNAME    Name to be used with saving the file output. Cannot be used if you are saving more than one file.
       --glob, --wildcard    Interpret all paths as having wildcards. Incompatible with --out-name.
       --ignore-rtfde        Ignores all errors thrown from RTFDE when trying to save. Useful for allowing fallback to continue when an exception happens.
@@ -232,8 +233,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.37.1 -blue.svg
-   :target: https://pypi.org/project/extract-msg/0.37.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.38.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.38.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-11-27'
-__version__ = '0.37.1'
+__date__ = '2022-11-29'
+__version__ = '0.38.0'
 
 import logging
 

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -62,6 +62,7 @@ def main() -> None:
             'contentId': args.cid,
             'customFilename': args.outName,
             'customPath': out,
+            'extractEmbedded': args.extractEmbedded,
             'html': args.html,
             'json': args.json,
             'pdf': args.pdf,

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -79,10 +79,7 @@ class Attachment(AttachmentBase):
             # If filename is None at this point, use long filename as first
             # preference.
             if not filename:
-                filename = self.longFilename
-            # Otherwise use the short filename.
-            if not filename:
-                filename = self.shortFilename
+                filename = self.name
             # Otherwise just make something up!
             if not filename:
                 return self.randomFilename
@@ -204,7 +201,12 @@ class Attachment(AttachmentBase):
 
             return str(fullFilename)
         else:
-            self.saveEmbededMessage(**kwargs)
+            if kwargs.get('extractEmbedded', False):
+                # TODO
+                with _open(str(fullFilename), mode) as f:
+                    self.data.export(f)
+            else:
+                self.saveEmbededMessage(**kwargs)
 
             # Close the ZipFile if this function created it.
             if _zip and createdZip:

--- a/extract_msg/attachment.py
+++ b/extract_msg/attachment.py
@@ -120,6 +120,10 @@ class Attachment(AttachmentBase):
         either pass a path to where you want to create one or pass an instance
         to :param zip:. If :param zip: is an instance, :param customPath: will
         refer to a location inside the zip file.
+
+        :param extractEmbedded: If true, causes the attachment, should it be an
+            embedded MSG file, to save as a .msg file instead of calling it's
+            save function.
         """
         # First check if we are skipping embedded messages and stop
         # *immediately* if we are.

--- a/extract_msg/attachment_base.py
+++ b/extract_msg/attachment_base.py
@@ -279,6 +279,13 @@ class AttachmentBase:
         return self.__dir
 
     @property
+    def displayName(self) -> Optional[str]:
+        """
+        Returns the display name of the folder.
+        """
+        return self._ensureSet('_displayName', '__substg1.0_3001')
+
+    @property
     def exceptionReplaceTime(self) -> Optional[datetime.datetime]:
         """
         The original date and time at which the instance in the recurrence
@@ -335,6 +342,9 @@ class AttachmentBase:
         """
         The best name available for the file. Uses long filename before short.
         """
+        if type == AttachmentType.MSG:
+            if self.displayName:
+                return self.displayName + '.msg'
         return self.longFilename or self.shortFilename
 
     @property

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -445,6 +445,8 @@ NEEDS_ARG = (
 MAINDOC = "extract_msg:\n\tExtracts emails and attachments saved in Microsoft Outlook's .msg files.\n\n" \
           "https://github.com/TeamMsgExtractor/msg-extractor"
 
+# Default class ID for the root entry for OleWriter. This should be
+# referencing Outlook if I understand it correctly.
 DEFAULT_CLSID = b'\x0b\r\x02\x00\x00\x00\x00\x00\xc0\x00\x00\x00\x00\x00\x00F'
 
 # Define pre-compiled structs to make unpacking slightly faster.

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -456,6 +456,8 @@ ST_SYSTEMTIME = struct.Struct('<8H')
 ST_GUID = struct.Struct('<IHH8s')
 # Struct for unpacking a TimeZoneStruct from bytes.
 ST_TZ = struct.Struct('<iiiH16sH16s')
+# Struct for packing a compount file directory entry.
+ST_CF_DIR_ENTRY = struct.Struct('<64sHBBIII16sIQQIII')
 # Structs used by data.py
 ST_DATA_UI32 = struct.Struct('<I')
 ST_DATA_UI16 = struct.Struct('<H')

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -457,7 +457,7 @@ ST_GUID = struct.Struct('<IHH8s')
 # Struct for unpacking a TimeZoneStruct from bytes.
 ST_TZ = struct.Struct('<iiiH16sH16s')
 # Struct for packing a compount file directory entry.
-ST_CF_DIR_ENTRY = struct.Struct('<64sHBBIII16sIQQIII')
+ST_CF_DIR_ENTRY = struct.Struct('<64sHBBIII16sIQQIQ')
 # Structs used by data.py
 ST_DATA_UI32 = struct.Struct('<I')
 ST_DATA_UI16 = struct.Struct('<H')

--- a/extract_msg/constants.py
+++ b/extract_msg/constants.py
@@ -445,6 +445,8 @@ NEEDS_ARG = (
 MAINDOC = "extract_msg:\n\tExtracts emails and attachments saved in Microsoft Outlook's .msg files.\n\n" \
           "https://github.com/TeamMsgExtractor/msg-extractor"
 
+DEFAULT_CLSID = b'\x0b\r\x02\x00\x00\x00\x00\x00\xc0\x00\x00\x00\x00\x00\x00F'
+
 # Define pre-compiled structs to make unpacking slightly faster.
 # General structs.
 ST1 = struct.Struct('<8x4I')

--- a/extract_msg/enums.py
+++ b/extract_msg/enums.py
@@ -311,6 +311,10 @@ class ClientIntentFlag(enum.Enum):
 
 
 
+class Color(enum.IntEnum):
+    RED = 0
+    BLACK = 1
+
 
 class ContactAddressIndex(enum.Enum):
     EMAIL_1 = 0
@@ -345,6 +349,15 @@ class DeencapType(enum.Enum):
     """
     PLAIN = 0
     HTML = 1
+
+
+
+class DirectoryEntryType(enum.IntEnum):
+    UNALLOCATED = 0
+    UNKNOWN = 0
+    STORAGE = 1
+    STREAM = 2
+    ROOT_STORAGE = 5
 
 
 

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -313,7 +313,6 @@ class MSGFile:
         This should ALWAYS return a string if it was found, otherwise returns
         None.
         """
-
         filename = self.fixPath(filename, prefix)
         if self.areStringsUnicode:
             return windowsUnicode(self._getStream(filename + '001F', prefix = False))
@@ -409,6 +408,17 @@ class MSGFile:
                         contents = streams
                 return True, parseType(int(_type, 16), contents, self.stringEncoding, extras)
         return False, None # We didn't find the stream.
+
+    def _oleListDir(self, streams : bool = True, storages : bool = False) -> List:
+        """
+        Calls :method OleFileIO.listdir: from the OleFileIO instance associated
+        with this MSG file. Useful for if you need access to all the top level
+        streams if this is an embedded MSG file.
+
+        Returns a list of the streams and or storages depending on the arguments
+        given.
+        """
+        return self.__ole.listdir(streams, storages)
 
     def close(self) -> None:
         if self.__open:

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -492,14 +492,17 @@ class MSGFile:
             inp = self.__prefix + inp
         return inp
 
-    def listDir(self, streams : bool = True, storages : bool = False) -> List[List]:
+    def listDir(self, streams : bool = True, storages : bool = False, includePrefix : bool = True) -> List[List]:
         """
         Replacement for OleFileIO.listdir that runs at the current prefix
         directory.
+
+        :param includePrefix: If false, removed the part of the path that is the
+            prefix.
         """
         # Get the items from OleFileIO.
         try:
-            return self.__listDirRes[(streams, storages)]
+            return self.__listDirRes[(streams, storages, includePrefix)]
         except KeyError:
             entries = self.__ole.listdir(streams, storages)
             if not self.__prefix:
@@ -509,8 +512,12 @@ class MSGFile:
                 prefix.pop()
 
             prefixLength = self.__prefixLen
-            self.__listDirRes[(streams, storages)] = [x for x in entries if len(x) > prefixLength and x[:prefixLength] == prefix]
-            return self.__listDirRes[(streams, storages)]
+            entries = [x for x in entries if len(x) > prefixLength and x[:prefixLength] == prefix]
+            if not includePrefix:
+                entries = [x[prefixLength:] for x in entries]
+            self.__listDirRes[(streams, storages, includePrefix)] = entries
+
+            return self.__listDirRes[(streams, storages, includePrefix)]
 
     def slistDir(self, streams : bool = True, storages : bool = False) -> List[str]:
         """

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -18,7 +18,7 @@ from .exceptions import InvalidFileFormatError, UnrecognizedMSGTypeError
 from .named import Named, NamedProperties
 from .prop import FixedLengthProp
 from .properties import Properties
-from .utils import divide, getEncodingName, hasLen, inputToMsgpath, inputToString, msgpathToString, parseType, properHex, verifyPropertyId, verifyType, windowsUnicode
+from .utils import divide, getEncodingName, hasLen, inputToMsgPath, inputToString, msgPathToString, parseType, properHex, verifyPropertyId, verifyType, windowsUnicode
 
 
 logger = logging.getLogger(__name__)
@@ -271,6 +271,22 @@ class MSGFile:
             setattr(self, variable, value)
             return value
 
+    def _getOleEntry(self, filename, prefix : bool = True) -> olefile.OleDirectoryEntry:
+        """
+        Finds the directory entry from the olefile for the stream or storage
+        specified. Use '/' to get the root entry.
+        """
+        sid = -1
+        if filename == '/':
+            if prefix:
+                sid = self.__ole._find(self.__prefix)
+            else:
+                return self.__ole.direntries[sid = 0]
+        else:
+            sid = self.__ole._find(self.fixPath(filename, prefix))
+
+        return self.__ole.direntries[sid]
+
     def _getStream(self, filename, prefix : bool = True) -> Optional[bytes]:
         """
         Gets a binary representation of the requested filename.
@@ -448,7 +464,7 @@ class MSGFile:
         prefixList = self.prefixList if prefix else []
         if location is not None:
             prefixList.append(location)
-        prefixList = inputToMsgpath(prefixList)
+        prefixList = inputToMsgPath(prefixList)
         usableId = _id + _type if _type else _id
         foundNumber = 0
         foundStreams = []
@@ -471,7 +487,7 @@ class MSGFile:
         Changes paths so that they have the proper prefix (should :param prefix:
         be True) and are strings rather than lists or tuples.
         """
-        inp = msgpathToString(inp)
+        inp = msgPathToString(inp)
         if prefix:
             inp = self.__prefix + inp
         return inp
@@ -501,7 +517,7 @@ class MSGFile:
         Replacement for OleFileIO.listdir that runs at the current prefix
         directory. Returns a list of strings instead of lists.
         """
-        return [msgpathToString(x) for x in self.listDir(streams, storages)]
+        return [msgPathToString(x) for x in self.listDir(streams, storages)]
 
     def save(self, *args, **kwargs):
         raise NotImplementedError(f'Saving is not yet supported for the {self.__class__.__name__} class.')

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -271,7 +271,7 @@ class MSGFile:
             setattr(self, variable, value)
             return value
 
-    def _getOleEntry(self, filename, prefix : bool = True) -> olefile.OleDirectoryEntry:
+    def _getOleEntry(self, filename, prefix : bool = True) -> olefile.olefile.OleDirectoryEntry:
         """
         Finds the directory entry from the olefile for the stream or storage
         specified. Use '/' to get the root entry.
@@ -281,7 +281,7 @@ class MSGFile:
             if prefix:
                 sid = self.__ole._find(self.__prefix)
             else:
-                return self.__ole.direntries[sid = 0]
+                return self.__ole.direntries[0]
         else:
             sid = self.__ole._find(self.fixPath(filename, prefix))
 

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -482,6 +482,24 @@ class MSGFile:
                     foundNumber += 1
         return (foundNumber > 0), foundNumber
 
+    def export(self, path) -> None:
+        """
+        Exports the contents of this MSG file to a new MSG files specified by
+        the path given. If this is an embedded MSG file, the embedded streams
+        and directories will be added to it as if they were at the root,
+        allowing you to save it as it's own MSG file.
+
+        :param path: An IO device with a write method which accepts bytes or a
+            path-like object (including strings and pathlib.Path objects).
+        """
+        from .ole_writer import OleWriter
+
+        # Create an instance of the class used for writing a new OLE file.
+        writer = OleWriter()
+        # Add all file and directory entries to it. If this
+        writer.fromMsg(self)
+        writer.write(path)
+
     def fixPath(self, inp, prefix : bool = True) -> str:
         """
         Changes paths so that they have the proper prefix (should :param prefix:

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -7,6 +7,35 @@ from . import constants
 from .utils import ceilDiv
 
 
+class _DirectoryEntry:
+    """
+    Hidden class, will probably be modified later.
+    """
+    name : str = ''
+
+    def __init__(self):
+        pass
+
+    def toBytes(self):
+        """
+        Converts the entry to bytes to be writen to a file.
+        """
+        ret = b''
+        # First write the name and the name length.
+        if len(self.name) > 31:
+            raise ValueError('Name is too long for directory entry.')
+        if len(self.name) < 1:
+            raise ValueError('Directory entry must have a name.')
+
+        ret += self.name.encode('utf-16-le')
+        ret += b'\x00\x00' * (32 - len(self.name))
+
+        ret += constants.ST_LE_UI16.pack(len(self.name) + 1)
+
+        # TODO.
+
+
+
 class OleWriter:
     """
     Takes data to write to a compound binary format file, as specified in
@@ -78,6 +107,8 @@ class OleWriter:
         # Finally, fill out the last DIFAT sector with null entries.
         if numFat > 109:
             f.write(b'\xFF\xFF\xFF\xFF' * ((numFat - 109) % 127))
+            # Finally, make sure to write the end of chain marker for the DIFAT.
+            f.write(b'\xFE\xFF\xFF\xFF')
         else:
             f.write(b'\xFF\xFF\xFF\xFF' * (109 - numFat))
 
@@ -114,6 +145,8 @@ class OleWriter:
             newNumFat = ceilDiv(self.__numberOfSectors + numDifat, 127)
 
         return (numFat, numDifat, self.__numberOfSectors + numDifat + numFat)
+
+    def _writeDirectoryEntry(entry : _DirectoryEntry)
 
 
     def write(self, path) -> None:

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -131,7 +131,7 @@ class OleWriter:
         root.name = "Root Entry"
         root.type = DirectoryEntryType.ROOT_STORAGE
         # Add the location of the start of the mini stream.
-        root.startingSectorLocation = (startingSector + ceilDiv(self.__dirEntryCount, 4) + self.__numMinifat) if self.__numMinifat > 0 else 0xFFFFFFFE
+        root.startingSectorLocation = (startingSector + ceilDiv(self.__dirEntryCount, 4) + ceilDiv(self.__numMinifatSectors, 128)) if self.__numMinifat > 0 else 0xFFFFFFFE
         root.streamSize = self.__numMinifatSectors * 64
         entries = [root]
 

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -7,7 +7,7 @@ from . import constants
 from .utils import ceilDiv
 
 
-class OleWritter:
+class OleWriter:
     """
     Takes data to write to a compound binary format file, as specified in
     [MS-CFB].
@@ -87,9 +87,11 @@ class OleWritter:
         # were all a part of it.
         f.write(b'\xFC\xFF\xFF\xFF' * numDifat)
         # Second write that the next x sectors are all FAT sectors.
-        f.write(b'\xFD\xFF\xFF\xFF' * numberOfFat)
+        f.write(b'\xFD\xFF\xFF\xFF' * numFat)
 
         ### TODO: handle the rest of the actual sectors.
+        # TEMP!!!
+        f.write(b'\x88\x88\x88\x88' * (totalSectors - numDifat - numFat))
 
         # Finally, fill fat with markers to specify no block exists.
         freeSectors = totalSectors & 0x7F
@@ -132,7 +134,7 @@ class OleWritter:
         # an error.
         try:
             ### First we need to write the header.
-            self._writeHeader(f)
+            self._writeBeginning(f)
 
         finally:
             if opened:

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -142,8 +142,9 @@ class OleWriter:
                 continue
             # If the current item *only* has the directory's entry and no stream
             # entries, we are actually done.
-            # Create a tree and add all the items to it. We will add it as a
-            # tuple of the name and entry so it will actually sort.
+            # Create a tree and add all the items to it. We add it with a key
+            # that is a tuple of the length (as shorter is *always* less than
+            # longer) and the uppercase name, and the value is the actual entry.
             tree = RedBlackTree()
             for name in currentItem:
                 if not name.startswith('::'):
@@ -157,7 +158,7 @@ class OleWriter:
                         entries.append(val)
 
                     # Add the data to the tree.
-                    tree.add(name.upper(), val)
+                    tree.add((len(name), name.upper()), val)
 
             # Now that everything is added, we need to take our root and add it
             # as the child of the current entry.

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -1,0 +1,53 @@
+import io
+import pathlib
+
+from typing import Union
+
+
+class OleWritter:
+    """
+    Takes data to write to a compound binary format file, as specified in
+    [MS-CFB].
+    """
+    def __init__(self):
+        raise NotImplementedError('This class is unfinished and not ready to be used.')
+
+    def _writeHeader(self, f):
+        """
+        Writes the header to the file f.
+        """
+        # Header signature.
+        f.write(b'\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1)
+        # Header CLSID.
+        f.write(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+        # Minor version.
+        f.write(b'\x3E\x00')
+        # Major version. For now, we only support version 3.
+        f.write(b'\x03\x00')
+        # Byte order. Specifies that it is little endian.
+        f.write(b'\xFE\xFF')
+
+
+    def write(self, path) -> None:
+        """
+        Writes the data to the path specified. If :param path: has a write
+        method it will use the object directly.
+        """
+        opened = False
+
+        # First, let's open the file if it is not a writable object.
+        if hasattr(path, 'write') and hasattr(path.write, '__call__'):
+            f = path
+        else:
+            f = open(path, 'wb')
+            opened = True
+
+        # Make sure we close the file after everything, especially if there is
+        # an error.
+        try:
+            ### First we need to write the header.
+            self._writeHeader(f)
+
+        finally:
+            if opened:
+                f.close()

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -157,7 +157,7 @@ class OleWriter:
                         entries.append(val)
 
                     # Add the data to the tree.
-                    tree.add(name, val)
+                    tree.add(name.upper(), val)
 
             # Now that everything is added, we need to take our root and add it
             # as the child of the current entry.

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -163,6 +163,10 @@ class OleWriter:
             # as the child of the current entry.
             entry.childTreeRoot = tree.value
 
+            print('-----DOT START-----')
+            tree.to_dot()
+            print('-----DOT END-----')
+
             # Now we need to go through each node and set it's data based on
             # it's sort position.
             for node in tree.in_order():
@@ -468,13 +472,13 @@ class OleWriter:
             # Basically we just need to add a "reserved" section to it in a
             # specific place. So let's check if we are doing the properties
             # stream and then if we are embedded.
-            if x[0] == '__properties_version1.0' and msg.prefixLength > 0:
+            if x[0] == '__properties_version1.0' and msg.prefixLen > 0:
                 data = data[:24] + b'\x00\x00\x00\x00\x00\x00\x00\x00' + data[24:]
             self.addOleEntry(x, entry, data)
 
         # Now check if it is an embedded file. If so, we need to copy the named
         # properties streams (the metadata, not the values).
-        if msg.prefixLength > 0:
+        if msg.prefixLen > 0:
             try:
                 # Get the entry for the named properties directory and add it
                 # immediately if it exists. If it doesn't exist, this whole

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -163,10 +163,6 @@ class OleWriter:
             # as the child of the current entry.
             entry.childTreeRoot = tree.value
 
-            print('-----DOT START-----')
-            tree.to_dot()
-            print('-----DOT END-----')
-
             # Now we need to go through each node and set it's data based on
             # it's sort position.
             for node in tree.in_order():

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -3,6 +3,9 @@ import pathlib
 
 from typing import Union
 
+from . import constants
+from .utils import ceilDiv
+
 
 class OleWritter:
     """
@@ -12,12 +15,18 @@ class OleWritter:
     def __init__(self):
         raise NotImplementedError('This class is unfinished and not ready to be used.')
 
-    def _writeHeader(self, f):
+        self.__numberOfSectors = 0
+
+    def _writeBeginning(self, f):
         """
-        Writes the header to the file f.
+        Writes the beginning to the file :param f:. This includes the header,
+        DIFAT, and FAT blocks.
         """
+        # Since we are going to need these multiple times, get them now.
+        numFat, numDifat, totalSectors = self._getFatSectors()
+
         # Header signature.
-        f.write(b'\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1)
+        f.write(b'\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1')
         # Header CLSID.
         f.write(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
         # Minor version.
@@ -26,6 +35,83 @@ class OleWritter:
         f.write(b'\x03\x00')
         # Byte order. Specifies that it is little endian.
         f.write(b'\xFE\xFF')
+        # Sector shift.
+        f.write(b'\x09\x00')
+        # Mini sector shift.
+        f.write(b'\x06\x00')
+        # Reserved.
+        f.write(b'\x00\x00\x00\x00\x00\x00')
+        # Number of directory sectors. Version 3 says this *must* be 0.
+        f.write(constants.ST_LE_UI32.pack(0))
+        # Number of FAT sectors.
+        f.write(constants.ST_LE_UI32.pack(numFat))
+        # First directory sector location (Sector for the directory stream).
+        # We place that right after the DIFAT and FAT.
+        f.write(constants.ST_LE_UI32.pack(numFat + numDifat))
+        # Transation signature number.
+        f.write(b'\x00\x00\x00\x00')
+        # Mini stream cutoff size.
+        f.write(b'\x00\x10\x00\x00')
+        ### TODO: First mini FAT sector location.
+        f.write(b'\x00\x00\x00\x00')
+        ### TODO: Number of mini FAT sectors.
+        f.write(b'\x00\x00\x00\x00')
+        # First DIFAT sector location. If there are none, set to 0xFFFFFFFE (End
+        # of chain).
+        f.write(constants.ST_LE_UI32.pack(0 if numDifat else 0xFFFFFFFE))
+        # Number of DIFAT sectors.
+        f.write(constants.ST_LE_UI32.pack(numDifat))
+
+        # To make life easier on me, I'm having the code start with the DIFAT
+        # followed by the FAT sectors, as I can write them all at once before
+        # writing the actual contents of the file.
+
+        # Write the DIFAT sectors.
+        for x in range(numFat):
+            # This kind of sucks to code, ngl.
+            if x > 109 and (x - 109) % 127 == 0:
+                # If we are at the end of a DIFAT sector, write the jump.
+                f.write(constants.ST_LE_UI32.pack((x - 109) // 127))
+            # Write the next FAT sector location.
+            f.write(constants.ST_LE_UI32.pack(x + numDifat))
+
+        # Finally, fill out the last DIFAT sector with null entries.
+        if numFat > 109:
+            f.write(b'\xFF\xFF\xFF\xFF' * ((numFat - 109) % 127))
+        else:
+            f.write(b'\xFF\xFF\xFF\xFF' * (109 - numFat))
+
+        ### FAT.
+
+        # First, if we had any DIFAT sectors, write that the previous sectors
+        # were all a part of it.
+        f.write(b'\xFC\xFF\xFF\xFF' * numDifat)
+        # Second write that the next x sectors are all FAT sectors.
+        f.write(b'\xFD\xFF\xFF\xFF' * numberOfFat)
+
+        ### TODO: handle the rest of the actual sectors.
+
+        # Finally, fill fat with markers to specify no block exists.
+        freeSectors = totalSectors & 0x7F
+        if freeSectors:
+            f.write(b'\xFF\xFF\xFF\xFF' * (128 - freeSectors))
+
+    def _getFatSectors(self):
+        """
+        Returns a tuple containing the number of FAT sectors, the number of
+        DIFAT sectors, and the total number of sectors the saved file will have.
+        """
+        # Right now we just use an annoying while loop to get the numbers.
+        numDifat = 0
+        # All divisions are ceiling divisions, so we leave them as
+        numFat = ceilDiv(self.__numberOfSectors, 127) or 1
+        newNumFat = 1
+        while numFat != newNumFat:
+            numFat = newNumFat
+            numDifat = ceilDiv(max(numFat - 109, 0), 127)
+            newNumFat = ceilDiv(self.__numberOfSectors + numDifat, 127)
+
+        return (numFat, numDifat, self.__numberOfSectors + numDifat + numFat)
 
 
     def write(self, path) -> None:

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -1,10 +1,13 @@
 import io
 import pathlib
+import re
 
-from typing import Union
+from typing import List, Optional, Union
 
 from . import constants
-from .utils import ceilDiv
+from .enums import Color
+from .utils import ceilDiv, inputToMsgPath
+from red_black_tree_mod import RedBlackTree
 
 
 class _DirectoryEntry:
@@ -12,6 +15,27 @@ class _DirectoryEntry:
     Hidden class, will probably be modified later.
     """
     name : str = ''
+    rightChild : '_DirectoryEntry' = None
+    leftChild : '_DirectoryEntry' = None
+    childTreeRoot : '_DirectoryEntry' = None
+    stateBits : int = 0
+    creationTime : int = 0
+    modifiedTime : int = 0
+    type : DirectoryEntryType = DirectoryEntryType.UNALLOCATED
+
+    # These get set after things have been sorted by the red black tree.
+    id : int = -1
+    # This is the ID for the left child. The terminology in the docs is really
+    # annoying.
+    leftSiblingID : int = 0xFFFFFFFF
+    rightSiblingID : int = 0xFFFFFFFF
+    # This is the ID for the root of the child tree, if any.
+    childID : int = 0xFFFFFFFF
+    startingSectorLocation : int = 0
+    color : Color = Color.Black
+
+    clsid : bytes = b''
+    data : bytes = b''
 
     def __init__(self):
         pass
@@ -20,19 +44,31 @@ class _DirectoryEntry:
         """
         Converts the entry to bytes to be writen to a file.
         """
-        ret = b''
         # First write the name and the name length.
         if len(self.name) > 31:
             raise ValueError('Name is too long for directory entry.')
         if len(self.name) < 1:
             raise ValueError('Directory entry must have a name.')
+        if re.search('/\\\\:!', self.name):
+            raise ValueError('Directory entry name contains an illegal character.')
 
-        ret += self.name.encode('utf-16-le')
-        ret += b'\x00\x00' * (32 - len(self.name))
+        nameBytes = self.name.encode('utf-16-le')
 
-        ret += constants.ST_LE_UI16.pack(len(self.name) + 1)
-
-        # TODO.
+        return constants.ST_CF_DIR_ENTRY.pack(
+                                              nameBytes,
+                                              len(nameBytes),
+                                              self.type,
+                                              self.color,
+                                              self.leftSiblingID,
+                                              self.rightSiblingID,
+                                              self.childID,
+                                              self.clsid,
+                                              self.stateBits,
+                                              self.creationTime,
+                                              self.modifiedTime,
+                                              self.startingSectorLocation,
+                                              len(self.data)
+                                             )
 
 
 
@@ -44,12 +80,43 @@ class OleWriter:
     def __init__(self):
         raise NotImplementedError('This class is unfinished and not ready to be used.')
 
-        self.__numberOfSectors = 0
+        #self.__numberOfSectors = 0
+        # The root entry will always exist, so this must be at least 1.
+        self.__dirEntryCount = 1
+        self.__dirEntries = {}
+        self.__largeEntries = []
 
-    def _writeBeginning(self, f):
+    @property
+    def __numberOfSectors(self) -> int:
+        """
+        TODO: finish the calculation needed. For now this just notes how many
+        sectors are needed for the directory entries.
+        """
+        return ceilDiv(self.__dirEntryCount, 4)
+
+    def _getFatSectors(self):
+        """
+        Returns a tuple containing the number of FAT sectors, the number of
+        DIFAT sectors, and the total number of sectors the saved file will have.
+        """
+        # Right now we just use an annoying while loop to get the numbers.
+        numDifat = 0
+        # All divisions are ceiling divisions, so we leave them as
+        numFat = ceilDiv(self.__numberOfSectors, 127) or 1
+        newNumFat = 1
+        while numFat != newNumFat:
+            numFat = newNumFat
+            numDifat = ceilDiv(max(numFat - 109, 0), 127)
+            newNumFat = ceilDiv(self.__numberOfSectors + numDifat, 127)
+
+        return (numFat, numDifat, self.__numberOfSectors + numDifat + numFat)
+
+    def _writeBeginning(self, f) -> int:
         """
         Writes the beginning to the file :param f:. This includes the header,
         DIFAT, and FAT blocks.
+
+        :returns: The current sector number after all the data is written.
         """
         # Since we are going to need these multiple times, get them now.
         numFat, numDifat, totalSectors = self._getFatSectors()
@@ -81,10 +148,10 @@ class OleWriter:
         f.write(b'\x00\x00\x00\x00')
         # Mini stream cutoff size.
         f.write(b'\x00\x10\x00\x00')
-        ### TODO: First mini FAT sector location.
-        f.write(b'\x00\x00\x00\x00')
-        ### TODO: Number of mini FAT sectors.
-        f.write(b'\x00\x00\x00\x00')
+        # First mini FAT sector location.
+        f.write(constants.ST_LE_UI32.pack((numFat + numDifat + self.__dirEntryCount) if self.__numMinifat > 0 else 0xFFFFFFFE))
+        # Number of mini FAT sectors.
+        f.write(constants.ST_LE_UI32.pack(self.__numMinifat))
         # First DIFAT sector location. If there are none, set to 0xFFFFFFFE (End
         # of chain).
         f.write(constants.ST_LE_UI32.pack(0 if numDifat else 0xFFFFFFFE))
@@ -120,33 +187,180 @@ class OleWriter:
         # Second write that the next x sectors are all FAT sectors.
         f.write(b'\xFD\xFF\xFF\xFF' * numFat)
 
-        ### TODO: handle the rest of the actual sectors.
-        # TEMP!!!
-        f.write(b'\x88\x88\x88\x88' * (totalSectors - numDifat - numFat))
+        offset = numDifat + numFat
+
+        # Fill in the values for the directory stream.
+        for x in range(offset + 1, offset + ceilDiv(self.__dirEntryCount, 4)):
+            f.write(constants.ST_LE_UI32.pack(x))
+
+        # Write the end of chain marker.
+        f.write(b'\xFE\xFF\xFF\xFF')
+
+        offset += ceilDiv(self.__dirEntryCount, 4)
+
+        # Mini FAT chain.
+        for x in range(offset + 1, offset + ceilDiv(self.__numMinifat, 128)):
+            f.write(constants.ST_LE_UI32.pack(x))
+
+        # Write the end of chain marker.
+        f.write(b'\xFE\xFF\xFF\xFF')
+
+        offset += ceilDiv(self.__numMinifat, 128)
+
+        # The mini stream sectors.
+        for x in range(offset + 1, offset + self.__numMinifat):
+            f.write(constants.ST_LE_UI32.pack(x))
+
+        # Write the end of chain marker.
+        f.write(b'\xFE\xFF\xFF\xFF')
+
+        offset += self.__numMinifat
+
+        # Regular stream chains. These are the most complex to handle. We handle
+        # them by checking a list that was make of entries which were only added
+        # to that list if the size was more than 4096. The order in the list is
+        # how they will eventually be stored into the file correctly.
+        for entry in largeStorage:
+            size = ceilDiv(len(entry.data), 512)
+            for x in range(offset + 1, offset + size):
+                f.write(constants.ST_LE_UI32.pack(x))
+
+            # Write the end of chain marker.
+            f.write(b'\xFE\xFF\xFF\xFF')
+
+            offset += size
 
         # Finally, fill fat with markers to specify no block exists.
         freeSectors = totalSectors & 0x7F
         if freeSectors:
             f.write(b'\xFF\xFF\xFF\xFF' * (128 - freeSectors))
 
-    def _getFatSectors(self):
-        """
-        Returns a tuple containing the number of FAT sectors, the number of
-        DIFAT sectors, and the total number of sectors the saved file will have.
-        """
-        # Right now we just use an annoying while loop to get the numbers.
-        numDifat = 0
-        # All divisions are ceiling divisions, so we leave them as
-        numFat = ceilDiv(self.__numberOfSectors, 127) or 1
-        newNumFat = 1
-        while numFat != newNumFat:
-            numFat = newNumFat
-            numDifat = ceilDiv(max(numFat - 109, 0), 127)
-            newNumFat = ceilDiv(self.__numberOfSectors + numDifat, 127)
+        # Finally, return the current sector index for use in other places.
+        return numDifat + numFat
 
-        return (numFat, numDifat, self.__numberOfSectors + numDifat + numFat)
+    def _writeDirectoryEntries(self, f, startingSector : int) -> List[_DirectorEntry]:
+        """
+        Writes out all the directory entries. Returns the list generated.
+        """
+        entries = self._treeSort(startingSector)
+        for x in entries:
+            self._writeDirectoryEntry(self, f, x)
+        if len(entries) & 3:
+            f.write(((b'\x00\x00' * 34) + (b'\xFF\xFF' * 6) + (b'\x00\x00' * 24)) * (4 - (len(entries) & 3)))
 
-    def _writeDirectoryEntry(entry : _DirectoryEntry)
+        return entries
+
+    def _writeDirectoryEntry(self, f, entry : _DirectoryEntry):
+        """
+        Writes the directory entry to the file f.
+        """
+        f.write(entry.toBytes())
+
+    def _treeSort(self, startingSector : int) -> List[_DirectoryEntry]:
+        """
+        Uses red-black trees to sort the internal data in preparation for
+        writing the file, returning a list, in order, of the entries to write.
+        """
+        # First, create the root entry.
+        root = _DirectorEntry()
+        root.name = "Root Entry"
+        root.type = DirectoryEntryType.ROOT_STORAGE
+        # Add the location of the start of the mini stream.
+        root.startingSectorLocation = (startingSector + ceilDiv(self.__dirEntryCount, 4) + self.__numMinifat) if self.__numMinifat > 0 else 0xFFFFFFFE
+
+        entries = [root]
+
+        toProcess = [(root, self.__dirEntries)]
+        # Continue looping while there is more to process.
+        while toProcess:
+            entry, currentItem = toProcess.pop()
+            # If the current item *only* has the directory's entry and no stream
+            # entries, we are actually done.
+            # Create a tree and add all the items to it. We will add it as a
+            # tuple of the name and entry so it will actually sort.
+            tree = RedBlackTree()
+            for name in currentItem:
+                if not name.startswith('::'):
+                    val = currentItem[name]
+                    # If we find a directory entry, then we need to add it to
+                    # the processing list.
+                    if isinstance(val, dict):
+                        toProcess.append((val['::DirectoryEntry'], val))
+                        tree.append(val['::DirectoryEntry'])
+                    else:
+                        tree.append(val)
+
+                    # Add the data to the tree.
+                    tree.add((name, val))
+
+            # Now that everything is added, we need to take our root and add it
+            # as the child of the current entry.
+            entry.childTreeRoot = tree.value[1]
+
+            # Now we need to go through each node and set it's data based on
+            # it's sort position.
+            for node in tree:
+                item = node.value[1]
+                # Set the color immediately.
+                item.color = Color.BLACK if node.is_black else Color.RED
+                if node.left:
+                    val = node.left.value[1]
+                    if isinstance(val, _DirectoryEntry):
+                        item.leftChild = val
+                    else:
+                        item.leftChild = val['::DirectoryEntry']
+                else:
+                    item.leftChild = None
+                if node.right:
+                    val = node.right.value[1]
+                    if isinstance(val, _DirectoryEntry):
+                        item.rightChild = val
+                    else:
+                        item.rightChild = val['::DirectoryEntry']
+                else:
+                    item.rightChild = None
+
+        # Now that everything is connected, we loop over the entries list a few
+        # times and set the data values.
+        for _id, entry in enumerate(entries):
+            entry.id = _id
+
+        for entry in entries:
+            entry.leftSiblingID = entry.leftChild.id if entry.leftChild else 0xFFFFFFFF
+            entry.childID = entry.childTreeRoot.id if entry.childTreeRoot else 0xFFFFFFFF
+            entry.rightSiblingID = entry.rightChild.id if entry.rightChild else 0xFFFFFFFF
+
+        # Finally, let's figure out the sector IDs to be used for the data.
+
+        return entries
+
+    def addOleEntry(self, path, entry : OleDirectoryEntry, data : Optional[bytes] = None) -> None:
+        """
+        Uses the entry provided to add the data to the writer.
+
+        :raises ValueError: Tried to add an entry to a path that has not yet
+            been added.
+        """
+        pathList = inputToMsgPath(path)
+        # First, find the current place in our dict to add the item.
+        _dir = self.__dirEntries
+        while len(pathList) > 1:
+            if pathlist[0] not in _dir:
+                # If no entry has been provided already for the directory, that
+                # is considered a fatal error.
+                raise ValueError('Path not found.')
+            _dir = _dir[pathlist[0]]
+
+        # Now that we are in the right place, add our data.
+
+        self.__dirEntryCount += 1
+
+
+    def fromMsg(self, msg : 'MSGFile') -> None:
+        """
+        Copies the streams and stream information necessary from the MSG file.
+        """
+
 
 
     def write(self, path) -> None:

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -79,9 +79,6 @@ class OleWriter:
     [MS-CFB].
     """
     def __init__(self):
-        #raise NotImplementedError('This class is unfinished and not ready to be used.')
-
-        #self.__numberOfSectors = 0
         # The root entry will always exist, so this must be at least 1.
         self.__dirEntryCount = 1
         self.__dirEntries = {}

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -463,6 +463,13 @@ class OleWriter:
         for x in entries:
             entry = msg._getOleEntry(x)
             data = msg._getStream(x) if entry.entry_type == DirectoryEntryType.STREAM else None
+            # THe properties stream on embedded messages actualy needs to be
+            # transformed a little (*why* it is like that is a mystery to me).
+            # Basically we just need to add a "reserved" section to it in a
+            # specific place. So let's check if we are doing the properties
+            # stream and then if we are embedded.
+            if x[0] == '__properties_version1.0' and msg.prefixLength > 0:
+                data = data[:24] + b'\x00\x00\x00\x00\x00\x00\x00\x00' + data[24:]
             self.addOleEntry(x, entry, data)
 
         # Now check if it is an embedded file. If so, we need to copy the named

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -310,6 +310,9 @@ def getCommandArgs(args) -> argparse.Namespace:
     # --skip-embedded
     parser.add_argument('--skip-embedded', dest='skipEmbedded', action='store_true',
                         help='Skips all embedded MSG files when saving attachments.')
+    # --extract-embedded
+    parser.add_argument('--extract-embedded', dest='extractEmbedded', action='store_true',
+                        help='Extracts the embedded MSG files as MSG files instead of running their save functions.')
     # --skip-not-implemented
     parser.add_argument('--skip-not-implemented', '--skip-ni', dest='skipNotImplemented', action='store_true',
                         help='Skips any attachments that are not implemented, allowing saving of the rest of the message.')

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -114,6 +114,20 @@ def ceilDiv(n : int, d : int) -> int:
     return -(n // -d)
 
 
+def cloneOleFile(sourcePath, outputPath) -> None:
+    """
+    Uses the OleWriter class to clone the specified OLE file into a new
+    location. Mainly designed for testing.
+    """
+    from .ole_writer import OleWriter
+
+    with olefile.OleFileIO(sourcePath) as f:
+        writer = OleWriter()
+        writer.fromOleFile(f)
+
+    writer.write(outputPath)
+
+
 def createZipOpen(func):
     """
     Creates a wrapper for the open function of a ZipFile that will automatically

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -459,14 +459,14 @@ def inputToBytes(stringInputVar, encoding) -> bytes:
         raise ConversionError('Cannot convert to bytes.')
 
 
-def inputToMsgpath(inp) -> List:
+def inputToMsgPath(inp) -> List:
     """
     Converts the input into an msg path.
     """
     if isinstance(inp, (list, tuple)):
         inp = '/'.join(inp)
-    ret = inputToString(inp, 'utf-8').replace('\\', '/').split('/')
-    return ret if ret[0] != '' else []
+    ret = [x for x in inputToString(inp, 'utf-8').replace('\\', '/').split('/') if x]
+    return ret
 
 
 def inputToString(bytesInputVar, encoding) -> str:
@@ -524,9 +524,9 @@ def filetimeToUtc(inp : int) -> float:
     return (inp - 116444736000000000) / 10000000.0
 
 
-def msgpathToString(inp) -> str:
+def msgPathToString(inp) -> str:
     """
-    Converts an msgpath (one of the internal paths inside an msg file) into a
+    Converts an MSG path (one of the internal paths inside an MSG file) into a
     string.
     """
     if inp is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 
 # First level requirements
-imapclient>=2.1.0
+imapclient>=2.3.0<3
 olefile==0.46
-tzlocal>=4.2
-compressed_rtf>=1.0.6
-ebcdic>=1.1.1
-beautifulsoup4>=4.11.1
-RTFDE>=0.0.2
-chardet>=4.0.0
+tzlocal==4.2
+compressed_rtf==1.0.6
+ebcdic==1.1.1
+beautifulsoup4>=4.11.1<4.12
+RTFDE==0.0.2
+chardet>=4.0.0<6
 red-black-tree-mod==1.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 
 # First level requirements
 imapclient>=2.1.0
-olefile>=0.46
+olefile==0.46
 tzlocal>=4.2
 compressed_rtf>=1.0.6
 ebcdic>=1.1.1
 beautifulsoup4>=4.11.1
 RTFDE>=0.0.2
 chardet>=4.0.0
+red-black-tree-mod==1.20

--- a/tests.py
+++ b/tests.py
@@ -10,7 +10,6 @@ TEST_FILE = "example-msg-files/unicode.msg"
 class TestCase(unittest.TestCase):
 
     def setUp(self):
-        shutil.rmtree("raw", ignore_errors=True)
         for name in os.listdir('.'):
             if os.path.isdir(name) and name.startswith('2013-11-18_1026'):
                 shutil.rmtree(name, ignore_errors=True)
@@ -42,11 +41,6 @@ class TestCase(unittest.TestCase):
             sorted(['message.text', 'import OleFileIO.tif',
                     'raised value error.tif']))
         msg.saveRaw()
-
-    def test_saveRaw(self):
-        msg = extract_msg.Message(TEST_FILE)
-        msg.saveRaw()
-        assert os.listdir('raw')
 
 
 unittest.main(verbosity=2)


### PR DESCRIPTION
**v0.38.0**
* [[TeamMsgExtractor #117](https://github.com/TeamMsgExtractor/msg-extractor/issues/117)] Added class `OleWriter` to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
* Added function `MSGFile.export` which copies all streams and storages from an MSG file into a new file. This can "clone" an MSG file or be used for extracting an MSG file that is embedded inside of another.
* Added hidden function to `MSGFile` for getting the `OleDirectoryEntry` for a storage or stream. This is mainly for use by the `OleWriter` class.
* Added option `extractEmbedded` to `Attachment.save` (`--extract-embedded` on the command line) which causes embedded MSG files to be extracted instead of running their save methods.
* Fixed minor issues with `utils.inputToMsgPath` (renamed from `utils.inputToMsgpath`).
* Renamed `utils.msgpathToString` to `utils.msgPathToString`.
* Made some of the module requirements a little more strict to better version control. I'll be trying to make periodic checks for updates to the dependency packages and make sure that new versions are compatible before changing the allowed versions, while also trying to keep the requirements a bit flexible.