### PR TITLE
v0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.38.1**
+* Added a `__del__` method to `MSGFile` to ensure a bit of proper cleanup should all references to an `MSGFile` instance be removed before the file is closed. `OleFileIO` doesn't appear to have one, so it's up to us to ensure it is properly closed. Note that the `del` keyword does not guarantee the immediate deletion of the object, and you should take care to close the file yourself. If this is not possible, importing the `gc` module and using it's `collect` method will free the files if your code has no references to them.
+* Fixed an import issue with signed messages.
+
 **v0.38.0**
 * [[TeamMsgExtractor #117](https://github.com/TeamMsgExtractor/msg-extractor/issues/117)] Added class `OleWriter` to allow the writing of OLE files, which allows for embedded MSG files to be extracted.
 * Added function `MSGFile.export` which copies all streams and storages from an MSG file into a new file. This can "clone" an MSG file or be used for extracting an MSG file that is embedded inside of another.

--- a/README.rst
+++ b/README.rst
@@ -233,8 +233,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.38.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.38.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.38.1-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.38.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2022-11-29'
-__version__ = '0.38.0'
+__date__ = '2022-12-01'
+__version__ = '0.38.1'
 
 import logging
 

--- a/extract_msg/message_signed_base.py
+++ b/extract_msg/message_signed_base.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from .exceptions import StandardViolationError
 from .message_base import MessageBase
 from .signed_attachment import SignedAttachment
-from .utils import inputToString, unwrapMultipart
+from .utils import inputToBytes, unwrapMultipart
 
 
 logger = logging.getLogger(__name__)

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -154,6 +154,9 @@ class MSGFile:
         if not self.__attachmentsDelayed:
             self.attachments
 
+    def __del__(self):
+        self.close()
+
     def __enter__(self):
         self.__ole.__enter__()
         return self


### PR DESCRIPTION
**v0.38.1**
* Added a `__del__` method to `MSGFile` to ensure a bit of proper cleanup should all references to an `MSGFile` instance be removed before the file is closed. `OleFileIO` doesn't appear to have one, so it's up to us to ensure it is properly closed. Note that the `del` keyword does not guarantee the immediate deletion of the object, and you should take care to close the file yourself. If this is not possible, importing the `gc` module and using it's `collect` method will free the files if your code has no references to them.
* Fixed an import issue with signed messages.