### PR TITLE
v0.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.39.2**
+* Fixed issues with `AttachmentBase.name` that could cause it to generate wrong.
+* Added convenience function `MSGFile.exportBytes` which returns the exported version from `MSGFile.export` as bytes instead of writing it to a file or file-like object.
+
 **v0.39.1**
 * [[TeamMsgExtractor #333](https://github.com/TeamMsgExtractor/msg-extractor/issues/333)] Fixed typo in a warning.
 * [[TeamMsgExtractor #334](https://github.com/TeamMsgExtractor/msg-extractor/issues/334)] Removed `__del__` method from `MSGFile`. It was there for cleanup, but wasn't planned well enough to stop it from causing issues. It may be reintroduced in the future if I can manage to remove the issues.

--- a/README.rst
+++ b/README.rst
@@ -234,8 +234,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.39.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.39.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.39.2-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.39.2/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.6+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-367/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__version__ = '0.39.1'
+__version__ = '0.39.2'
 __year__ = '2023'
 
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-02-12'
-__version__ = '0.39.1'
+__date__ = '2023-02-26'
+__version__ = '0.39.2'
 
 import logging
 

--- a/extract_msg/attachment_base.py
+++ b/extract_msg/attachment_base.py
@@ -342,7 +342,7 @@ class AttachmentBase:
         """
         The best name available for the file. Uses long filename before short.
         """
-        if type == AttachmentType.MSG:
+        if self.type is AttachmentType.MSG:
             if self.displayName:
                 return self.displayName + '.msg'
         return self.longFilename or self.shortFilename

--- a/extract_msg/msg.py
+++ b/extract_msg/msg.py
@@ -1,6 +1,7 @@
 import codecs
 import copy
 import datetime
+import io
 import logging
 import os
 import pathlib
@@ -516,6 +517,14 @@ class MSGFile:
         # Add all file and directory entries to it. If this
         writer.fromMsg(self)
         writer.write(path)
+
+    def exportBytes(self) -> bytes:
+        """
+        Saves a new copy of the MSG file, returning the bytes.
+        """
+        out = io.BytesIO()
+        self.export(out)
+        return out.getvalue()
 
     def fixPath(self, inp, prefix : bool = True) -> str:
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal=1
 all =
     extract-msg[mime]
 mime =
-    python-magic>=0.4.27,<0.5.0
+    python-magic>=0.4.27,<0.5


### PR DESCRIPTION
* Fixed issues with `AttachmentBase.name` that could cause it to generate wrong.
* Added convenience function `MSGFile.exportBytes` which returns the exported version from `MSGFile.export` as bytes instead of writing it to a file or file-like object.