### PR TITLE
Small typos in Enums, Props and Utils.

### DIFF
--- a/extract_msg/enums.py
+++ b/extract_msg/enums.py
@@ -400,7 +400,7 @@ class ElectronicAddressProperties(enum.Enum):
             raise ValueError('Value must not be negative.')
         # This is a quick compressed way to convert the bits in the int into
         # a tuple of instances of this class should any bit be a 1.
-        return {cls(int(x)) for index, val in enumerate(bin(value)[:1:-1]) if val == '1'}
+        return {cls(int(index)) for index, val in enumerate(bin(value)[:1:-1]) if val == '1'}
 
     EMAIL_1 = 0x00000000
     EMAIL_2 = 0x00000001

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -78,7 +78,7 @@ class PropBase:
         """
         The raw bytes used to create this object.
         """
-        return self.__raw
+        return self.__rawData
 
     @property
     def type(self) -> int:
@@ -152,7 +152,7 @@ class FixedLengthProp(PropBase):
                 value = filetimeToDatetime(rawTime)
             except ValueError as e:
                 logger.exception(e)
-                logger.error(self.raw)
+                logger.error(self.rawData)
         elif _type == 0x0048:  # PtypGuid
             # TODO parsing for this
             pass

--- a/extract_msg/prop.py
+++ b/extract_msg/prop.py
@@ -1,8 +1,6 @@
 import datetime
 import logging
 
-import olefile
-
 from typing import Any
 
 from . import constants
@@ -139,7 +137,7 @@ class FixedLengthProp(PropBase):
                 # wasn't. So we are just returning the int. However, we want to see
                 # if it is a normal error type.
                 try:
-                    logger.warning(f'REPORT TO DEVELOPERS: Error type of {ErrorType(value)} was found.')
+                    logger.warning(f'REPORT TO DEVELOPERS: Error type of {ErrorCode(value)} was found.')
                 except ValueError:
                     pass
         elif _type == 0x000B:  # PtypBoolean

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -794,7 +794,7 @@ def parseType(_type : int, stream, encoding, extras):
             # wasn't. So we are just returning the int. However, we want to see
             # if it is a normal error type.
             try:
-                logger.warning(f'REPORT TO DEVELOPERS: Error type of {ErrorType(value)} was found.')
+                logger.warning(f'REPORT TO DEVELOPERS: Error type of {ErrorCode(value)} was found.')
             except ValueError:
                 pass
         return value


### PR DESCRIPTION
- [ ] Issue #: (Replace text with #<issue_number>)
- [ ] Have you listed any changes to install or build dependencies?
- [ ] Ensured your changes are compatible with Python 2.7 (ONLY FOR v0.29).
- [ ] Have you updated the [CHANGELOG](CHANGELOG.md) with details of changes to the codebase, this includes new functionality, deprecated features, or any other material changes.
- [ ] If necessary, have you bumped the version number? We will usually do this for you.
- [ ] Have you included py.test tests with your pull request. (Not yet necessary)
- [X] Ensured your code is as close to PEP 8 compliant as possible?
- [X] Ensured your pull request is to the `next-release` branch (or `v0.29` if applicable)?

I found a file that is triggering this ValueError and believe those two lines related to the rawData had small typos. I took a look at that ErrorType and saw that it didn't exist (maybe renamed?) and assume that it meant to be ErrorCode. Lastly, I saw that x is not defined in that function of Enums and index makes sense. I can bring back the import of oletools if needed, but unless I'm missing something, it didn't look to be used in the class.

I am not certain it is necessary to have an issue created for such a small change, but would gladly create it if requested!

Thank you!

