### PR TITLE
chg: Remove upperbound version limit for bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ olefile==0.46
 tzlocal==4.2
 compressed_rtf==1.0.6
 ebcdic==1.1.1
-beautifulsoup4>=4.11.1,<4.12
+beautifulsoup4>=4.11.1
 RTFDE==0.0.2
 chardet>=4.0.0,<6
 red-black-tree-mod==1.20


### PR DESCRIPTION
As far as I can tell, there are no breaking changes in bs4 v4.12 so this limit can be removed as it will avoid issues with projects that are expecting beautifulsoup4 v4.12 as a minimal version.