### PR TITLE
Version 0.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **v0.41.1**
-* [[TeamMsgExtractor #357](https://github.com/TeamMsgExtractor/msg-extractor/issues/362)] Fixed an issue with the removal of the `--dev` option missing one of the checks (I swear I actually tested it).
+* [[TeamMsgExtractor #362](https://github.com/TeamMsgExtractor/msg-extractor/issues/362)] Fixed an issue with the removal of the `--dev` option missing one of the checks (I swear I actually tested it).
 
 **v0.41.0**
 * [[TeamMsgExtractor #357](https://github.com/TeamMsgExtractor/msg-extractor/issues/357)] Fixed an issue where the properties stream being absent would raise an error message that was not clear.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.41.1**
+* [[TeamMsgExtractor #357](https://github.com/TeamMsgExtractor/msg-extractor/issues/362)] Fixed an issue with the removal of the `--dev` option missing one of the checks (I swear I actually tested it).
+
 **v0.41.0**
 * [[TeamMsgExtractor #357](https://github.com/TeamMsgExtractor/msg-extractor/issues/357)] Fixed an issue where the properties stream being absent would raise an error message that was not clear.
 * [[TeamMsgExtractor #357](https://github.com/TeamMsgExtractor/msg-extractor/issues/357)] Added a way to suppress `StandardViolationError` for poorly created files. This may cause issues you might not expect since this exception is meant to stop the processing for a reason.

--- a/README.rst
+++ b/README.rst
@@ -250,8 +250,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.41.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.41.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.41.1-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.41.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-05-09'
-__version__ = '0.41.0'
+__date__ = '2023-05-10'
+__version__ = '0.41.1'
 
 __all__ = [
     # Modules:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -387,7 +387,7 @@ def getCommandArgs(args) -> argparse.Namespace:
     if options.outName and options.noFolders:
         raise IncompatibleOptionsError('--out-name is not compatible with --no-folders.')
 
-    if options.dev or options.fileLogging:
+    if options.fileLogging:
         options.verbose = options.verbose or 1
 
     # Handle the wkOptions if they exist.


### PR DESCRIPTION
**v0.41.1**
* [[TeamMsgExtractor #362](https://github.com/TeamMsgExtractor/msg-extractor/issues/362)] Fixed an issue with the removal of the `--dev` option missing one of the checks (I swear I actually tested it).