### PR TITLE
Fix for #365 (v0.41.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v0.41.3**
+* [[TeamMsgExtractor #365](https://github.com/TeamMsgExtractor/msg-extractor/issues/365)] Fixed an issue that would cause certain values retrieved from the header to not be decoded properly. It does this when retrieving the values, so nothing about the header has been changed.
+* Added new property `MessageBase.headerText` which is the text content of the header stream. Adjusted other things to use this instead of trying to retrieve the stream directly in multiple places.
+* Added typing to `MessageBase.header`.
+
 **v0.41.2**
 * Updated annotations on `MessageBase.save`.
 * Added new enum `BodyTypes`.

--- a/README.rst
+++ b/README.rst
@@ -250,8 +250,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.41.2-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.41.2/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.41.3-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.41.3/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-05-24'
-__version__ = '0.41.2'
+__date__ = '2023-06-10'
+__version__ = '0.41.3'
 
 __all__ = [
     # Modules:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -25,6 +25,7 @@ import codecs
 import collections
 import copy
 import datetime
+import email.header
 import email.message
 import email.policy
 import glob
@@ -167,6 +168,21 @@ def createZipOpen(func):
         return func(name, mode, *args, **kwargs)
 
     return _open
+
+
+def decodeRfc2047(encoded : str) -> str:
+    """
+    Decodes text encoded using the method specified in RFC 2047.
+    """
+    # This returns a list of tuples containing the bytes and the encoding they
+    # are using, so we decode each one and join them together.
+    #
+    # decode_header header will return a string instead of bytes for the first
+    # object if the input is not encoded, something that is frustrating.
+    return ''.join(
+        x[0].decode(x[1] or 'ascii') if isinstance(x[0], bytes) else x
+        for x in email.header.decode_header(encoded)
+    )
 
 
 def dictGetCasedKey(_dict : Dict, key : Any) -> Any:


### PR DESCRIPTION
**v0.41.3**
* [[TeamMsgExtractor #365](https://github.com/TeamMsgExtractor/msg-extractor/issues/365)] Fixed an issue that would cause certain values retrieved from the header to not be decoded properly. It does this when retrieving the values, so nothing about the header has been changed.
* Added new property `MessageBase.headerText` which is the text content of the header stream. Adjusted other things to use this instead of trying to retrieve the stream directly in multiple places.
* Added typing to `MessageBase.header`.