### PR TITLE
Fix bug with mimetype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.42.2**
+* Fix bug in `AttachmentBase.mimetype` that would cause it to throw an error when accessed. This bug was introduced in `v0.42.0`.
+
 **v0.42.1**
 * Fixed some constants being accessed with the wrong name (names were changed in reorganization).
 * Removed unused regular expression.

--- a/README.rst
+++ b/README.rst
@@ -242,8 +242,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.42.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.42.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.42.2-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.42.2/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-07-31'
-__version__ = '0.42.1'
+__date__ = '2023-08-02'
+__version__ = '0.42.2'
 
 __all__ = [
     # Modules:

--- a/extract_msg/attachments/attachment_base.py
+++ b/extract_msg/attachments/attachment_base.py
@@ -506,7 +506,7 @@ class AttachmentBase(abc.ABC):
         """
         The content-type mime header of the attachment, if specified.
         """
-        return self._getStreamAs('__substg1.0_370E', partial(tryGetMimetype, self), False)
+        return tryGetMimetype(self, self._getStringStream('__substg1.0_370E'))
 
     @property
     def msg(self) -> MSGFile:


### PR DESCRIPTION
**v0.42.2**
* Fix bug in `AttachmentBase.mimetype` that would cause it to throw an error when accessed. This bug was introduced in `v0.42.0`.