### PR TITLE
Support for #56 / #248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v0.43.0**
+* [[TeamMsgExtractor #56](https://github.com/TeamMsgExtractor/msg-extractor/issues/56)] [[TeamMsgExtractor #248](https://github.com/TeamMsgExtractor/msg-extractor/issues/248)] Added new function `MessageBase.asEmailMessage` which will convert the `MessageBase` instance, if possible, to an `email.message.EmailMessage` object. If an embedded MSG file on a `MessageBase` object is of a class that does not have this function, it will simply be attached to the instance as bytes.
+* Changed imports in `message_base.py` to help with type checkers.
+* Changed from using `email.parser.EmailParser` to `email.parser.HeaderParser` in `MessageBase.header`.
+* Changed some of the internal code for `MessageBase.header`. This should improve usage of it, and should not have any notiocable negative changes. You man notice some of the values parse slightly differently, but this effect should be mostly supressed.
+
 **v0.42.2**
 * Fix bug in `AttachmentBase.mimetype` that would cause it to throw an error when accessed. This bug was introduced in `v0.42.0`.
 

--- a/README.rst
+++ b/README.rst
@@ -242,8 +242,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.42.2-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.42.2/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.43.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.43.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2023-08-02'
-__version__ = '0.42.2'
+__version__ = '0.43.0'
 
 __all__ = [
     # Modules:

--- a/temp-changelog.md
+++ b/temp-changelog.md
@@ -1,0 +1,5 @@
+**v0.?.?**
+* Changed imports in `message_base.py` to help with type checkers.
+* Added new function `MessageBase.asEmailMessage` which will convert the `MessageBase` instance, if possible, to an `email.message.EmailMessage` object. If an embedded MSG file on a `MessageBase` object is of a class that does not have this function, it will simply be attached to the message as bytes.
+* Changed from using `email.parser.EmailParser` to `email.parser.HeaderParser` in `MessageBase.header`.
+* Changed some of the internal code for `MessageBase.header`. This should improve usage of it, and should not have any notiocable negative changes. You man notice some of the values parse slightly differently, but this effect should be mostly supressed.

--- a/temp-changelog.md
+++ b/temp-changelog.md
@@ -1,5 +1,0 @@
-**v0.?.?**
-* Changed imports in `message_base.py` to help with type checkers.
-* Added new function `MessageBase.asEmailMessage` which will convert the `MessageBase` instance, if possible, to an `email.message.EmailMessage` object. If an embedded MSG file on a `MessageBase` object is of a class that does not have this function, it will simply be attached to the message as bytes.
-* Changed from using `email.parser.EmailParser` to `email.parser.HeaderParser` in `MessageBase.header`.
-* Changed some of the internal code for `MessageBase.header`. This should improve usage of it, and should not have any notiocable negative changes. You man notice some of the values parse slightly differently, but this effect should be mostly supressed.


### PR DESCRIPTION
Added a function to `MessageBase` which allows the object to be converted to an `email.message.EmailMessage` instance, completely fulfilling #248 and at least partially fulfilling #56