### PR TITLE
Version 0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Minor regoanization within `extract_msg/utils.py`.
 * Minor changes to docstrings.
 * Minor README updates.
+* Fix issue with folded header fields decoding incorrectly when given to `extract_msg.utils.decodeRfc2047`.
 
 **v0.43.0**
 * [[TeamMsgExtractor #56](https://github.com/TeamMsgExtractor/msg-extractor/issues/56)] [[TeamMsgExtractor #248](https://github.com/TeamMsgExtractor/msg-extractor/issues/248)] Added new function `MessageBase.asEmailMessage` which will convert the `MessageBase` instance, if possible, to an `email.message.EmailMessage` object. If an embedded MSG file on a `MessageBase` object is of a class that does not have this function, it will simply be attached to the instance as bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v0.44.0**
+* Fixed a bug that caused `MessageBase.headerInit` to always return `False` after the 0.42.0 update.
+* Changed `MessageBase.headerInit` to a property.
+* Fixed `extract_msg.utils.__all__`.
+* Minor regoanization within `extract_msg/utils.py`.
+* Minor changes to docstrings.
+* Minor README updates.
+
 **v0.43.0**
 * [[TeamMsgExtractor #56](https://github.com/TeamMsgExtractor/msg-extractor/issues/56)] [[TeamMsgExtractor #248](https://github.com/TeamMsgExtractor/msg-extractor/issues/248)] Added new function `MessageBase.asEmailMessage` which will convert the `MessageBase` instance, if possible, to an `email.message.EmailMessage` object. If an embedded MSG file on a `MessageBase` object is of a class that does not have this function, it will simply be attached to the instance as bytes.
 * Changed imports in `message_base.py` to help with type checkers.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|License: GPL v3| |PyPI3| |PyPI2|
+|License: GPL v3| |PyPI3| |PyPI2| |Read the Docs|
 
 extract-msg
 =============
@@ -9,7 +9,7 @@ The python package extract_msg automates the extraction of key email
 data (from, to, cc, date, subject, body) and the email's attachments.
 
 Documentation can be found in the code, on the `wiki`_, and on the
-`read the docs`_ page.
+`Read the Docs`_ page.
 
 NOTICE
 ======
@@ -242,11 +242,16 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.43.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.43.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.44.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.44.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/
+
+.. |Read the Docs| image:: https://readthedocs.org/projects/msg-extractor/badge/?version=latest
+    :target: https://msg-extractor.readthedocs.io/en/stable/?badge=latest
+    :alt: Documentation Status
+
 .. _Matthew Walker: https://github.com/mattgwwalker
 .. _Destiny Peterson (The Elemental of Destruction): https://github.com/TheElementalOfDestruction
 .. _JP Bourget: https://github.com/punkrokk
@@ -261,5 +266,5 @@ your access to the newest major version of extract-msg.
 .. _Patreon: https://www.patreon.com/DestructionE
 .. _msg-explorer: https://pypi.org/project/msg-explorer/
 .. _wiki: https://github.com/TeamMsgExtractor/msg-extractor/wiki
-.. _read the docs: https://msg-extractor.rtfd.io/
+.. _Read the Docs: https://msg-extractor.rtfd.io/
 .. _Changelog: https://github.com/TeamMsgExtractor/msg-extractor/blob/master/CHANGELOG.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__version__ = '0.43.0'
+__version__ = '0.44.0'
 __year__ = '2023'
 
 

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-08-02'
-__version__ = '0.43.0'
+__date__ = '2023-08-03'
+__version__ = '0.44.0'
 
 __all__ = [
     # Modules:

--- a/extract_msg/msg_classes/calendar_base.py
+++ b/extract_msg/msg_classes/calendar_base.py
@@ -35,7 +35,7 @@ class CalendarBase(MessageBase):
         recipientInt = MeetingRecipientType(recipientInt)
         value = None
         # Check header first.
-        if self.headerInit():
+        if self.headerInit:
             value = self.header[recipientType]
             if value:
                 value = value.replace(',', self.recipientSeparator)
@@ -44,7 +44,7 @@ class CalendarBase(MessageBase):
         # it manually.
         if not value:
             # Check if the header has initialized.
-            if self.headerInit():
+            if self.headerInit:
                 logger.info(f'Header found, but "{recipientType}" is not included. Will be generated from other streams.')
 
             # Get a list of the recipients of the specified type.

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -15,6 +15,7 @@ __all__ = [
     'ceilDiv',
     'cloneOleFile',
     'createZipOpen',
+    'decodeRfc2047',
     'dictGetCasedKey',
     'divide',
     'filetimeToDatetime',
@@ -275,6 +276,13 @@ def filetimeToDatetime(rawTime : int) -> datetime.datetime:
         raise
     except Exception as e:
         raise ValueError(f'Timestamp value of {filetimeToUtc(rawTime)} caused an exception. This was probably caused by the time stamp being too far in the future.')
+
+
+def filetimeToUtc(inp : int) -> float:
+    """
+    Converts a FILETIME into a unix timestamp.
+    """
+    return (inp - 116444736000000000) / 10000000.0
 
 
 def findWk(path = None):
@@ -581,15 +589,6 @@ def inputToString(bytesInputVar, encoding) -> str:
         raise ConversionError('Cannot convert to str type.')
 
 
-def isEncapsulatedRtf(inp : bytes) -> bool:
-    """
-    Currently the detection is made to be *extremly* basic, but this will work
-    for now. In the future this will be fixed so that literal text in the body
-    of a message won't cause false detection.
-    """
-    return b'\\fromhtml' in inp
-
-
 def isEmptyString(inp : str) -> bool:
     """
     Returns true if the input is None or is an Empty string.
@@ -597,11 +596,13 @@ def isEmptyString(inp : str) -> bool:
     return (inp == '' or inp is None)
 
 
-def filetimeToUtc(inp : int) -> float:
+def isEncapsulatedRtf(inp : bytes) -> bool:
     """
-    Converts a FILETIME into a unix timestamp.
+    Currently the detection is made to be *extremly* basic, but this will work
+    for now. In the future this will be fixed so that literal text in the body
+    of a message won't cause false detection.
     """
-    return (inp - 116444736000000000) / 10000000.0
+    return b'\\fromhtml' in inp
 
 
 def makeWeakRef(obj : Optional[_T]) -> Optional[weakref.ReferenceType[_T]]:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -202,6 +202,9 @@ def decodeRfc2047(encoded : str) -> str:
     """
     Decodes text encoded using the method specified in RFC 2047.
     """
+    # Fix an issue with folded header fields.
+    encoded = encoded.replace('\r\n', '')
+
     # This returns a list of tuples containing the bytes and the encoding they
     # are using, so we decode each one and join them together.
     #


### PR DESCRIPTION
**v0.44.0**
* Fixed a bug that caused `MessageBase.headerInit` to always return `False` after the 0.42.0 update.
* Changed `MessageBase.headerInit` to a property.
* Fixed `extract_msg.utils.__all__`.
* Minor regoanization within `extract_msg/utils.py`.
* Minor changes to docstrings.
* Minor README updates.
* Fix issue with folded header fields decoding incorrectly when given to `extract_msg.utils.decodeRfc2047`.