### PR TITLE
Version 0.46.1: Fix #394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.46.1**
+* [[TeamMsgExtractor #394](https://github.com/TeamMsgExtractor/msg-extractor/issues/394)] Fix typo in props that caused the wrong number of bytes to be given to a struct.
+
 **v0.46.0**
 * [[TeamMsgExtractor #95](https://github.com/TeamMsgExtractor/msg-extractor/issues/95)] Adjusted the `overrideEncoding` property of `MSGFile` to allow automatic encoding detection. Simply set the property to the string `"chardet"` and, assuming the `chardet` module is installed, it will analyze a number of the strings to try and form a consensus about the encoding. This will *ignore* the specified encoding *only if* if successfully detects. Otherwise it will log a warning and fall back to the default behavior.
 * [[TeamMsgExtractor #387](https://github.com/TeamMsgExtractor/msg-extractor/issues/387)] Changed `extract_msg.utils.decodeRfc2047` to not throw decoding errors if the content given is not ASCII.

--- a/README.rst
+++ b/README.rst
@@ -259,8 +259,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.46.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.46.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.46.1-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.46.1/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-11-08'
-__version__ = '0.46.0'
+__date__ = '2023-11-09'
+__version__ = '0.46.1'
 
 __all__ = [
     # Modules:

--- a/extract_msg/properties/prop.py
+++ b/extract_msg/properties/prop.py
@@ -107,7 +107,7 @@ class FixedLengthProp(PropBase):
                 logger.warning('Property type is PtypNull, but is not equal to 0.')
             value = None
         elif _type == 0x0002: # PtypInteger16
-            value = constants.st.ST_LE_I16.unpack(value[:3])[0]
+            value = constants.st.ST_LE_I16.unpack(value[:2])[0]
         elif _type == 0x0003: # PtypInteger32
             value = constants.st.ST_LE_I32.unpack(value[:4])[0]
         elif _type == 0x0004: # PtypFloating32


### PR DESCRIPTION
**v0.46.1**
* [[TeamMsgExtractor #394](https://github.com/TeamMsgExtractor/msg-extractor/issues/394)] Fix typo in props that caused the wrong number of bytes to be given to a struct.