### PR TITLE
Version 0.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.46.2**
+* Adjusted typing information on regular expressions. They were using a subscript that was added in 3.9 (apparently that is something the type checker doesn't check for), which made the module incompatible with 3.8. If you are using 3.9 or higher a version check will switch to the more specific typing.
+
 **v0.46.1**
 * [[TeamMsgExtractor #394](https://github.com/TeamMsgExtractor/msg-extractor/issues/394)] Fix typo in props that caused the wrong number of bytes to be given to a struct.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **v0.46.2**
-* Adjusted typing information on regular expressions. They were using a subscript that was added in 3.9 (apparently that is something the type checker doesn't check for), which made the module incompatible with 3.8. If you are using 3.9 or higher a version check will switch to the more specific typing.
+* Adjusted typing information on regular expressions. They were using a subscript that was added in Python 3.9 (apparently that is something the type checker doesn't check for), which made the module incompatible with Python 3.8. If you are using Python 3.9 or higher a version check will switch to the more specific typing.
 
 **v0.46.1**
 * [[TeamMsgExtractor #394](https://github.com/TeamMsgExtractor/msg-extractor/issues/394)] Fix typo in props that caused the wrong number of bytes to be given to a struct.

--- a/README.rst
+++ b/README.rst
@@ -259,8 +259,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.46.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.46.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.46.2-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.46.2/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3816/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2023-11-09'
-__version__ = '0.46.1'
+__date__ = '2023-11-11'
+__version__ = '0.46.2'
 
 __all__ = [
     # Modules:

--- a/extract_msg/constants/re.py
+++ b/extract_msg/constants/re.py
@@ -17,16 +17,26 @@ import re
 from typing import Final
 
 
+# Allow better typing in versions above 3.8.
+import sys
+if sys.version_info >= (3, 9):
+    _RE_STR_TYPE = re.Pattern[str]
+    _RE_BYTES_TYPE = re.Pattern[bytes]
+else:
+    _RE_STR_TYPE = re.Pattern
+    _RE_BYTES_TYPE = re.Pattern
+
+
 # Characters that are invalid in a filename.
-INVALID_FILENAME_CHARS : Final[re.Pattern[str]] = re.compile(r'[\\/:*?"<>|]')
+INVALID_FILENAME_CHARS : Final[_RE_STR_TYPE] = re.compile(r'[\\/:*?"<>|]')
 # Regular expression to find sections of spaces for htmlSanitize.
-HTML_SAN_SPACE : Final[re.Pattern[str]] = re.compile('  +')
+HTML_SAN_SPACE : Final[_RE_STR_TYPE] = re.compile('  +')
 # Regular expression to find the start of the html body.
-HTML_BODY_START : Final[re.Pattern[bytes]] = re.compile(b'<body[^>]*>')
+HTML_BODY_START : Final[_RE_BYTES_TYPE] = re.compile(b'<body[^>]*>')
 # Regular expression to find the start of the html body in encapsulated RTF.
 # This is used for one of the pattern types that makes life easy.
-RTF_ENC_BODY_START : Final[re.Pattern[bytes]] = re.compile(br'\{\\\*\\htmltag[0-9]* ?<body[^>]*>\}')
+RTF_ENC_BODY_START : Final[_RE_BYTES_TYPE] = re.compile(br'\{\\\*\\htmltag[0-9]* ?<body[^>]*>\}')
 # Used in the vaildation of OLE paths. Any of these characters in a name make it
 # invalid.
-INVALID_OLE_PATH : Final[re.Pattern[str]] = re.compile(r'[:/\\!]')
+INVALID_OLE_PATH : Final[_RE_STR_TYPE] = re.compile(r'[:/\\!]')
 


### PR DESCRIPTION
**v0.46.2**
* Adjusted typing information on regular expressions. They were using a subscript that was added in Python 3.9 (apparently that is something the type checker doesn't check for), which made the module incompatible with Python 3.8. If you are using Python 3.9 or higher a version check will switch to the more specific typing.