### PR TITLE
Version 0.48.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.48.4**
+* [[TeamMsgExtractor #411](https://github.com/TeamMsgExtractor/msg-extractor/issues/411)] Fix console script throwing error due to changed console args not defaulting.
+
 **v0.48.3**
 * [[TeamMsgExtractor #409](https://github.com/TeamMsgExtractor/msg-extractor/issues/409)] Added missing private method to `SignedAttachment`.
 * Fixed some missing typing information.

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.3-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.48.3/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.4-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.48.4/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -28,7 +28,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 
 __author__ = 'Destiny Peterson & Matthew Walker'
 __date__ = '2024-03-20'
-__version__ = '0.48.3'
+__version__ = '0.48.4'
 
 __all__ = [
     # Modules:

--- a/extract_msg/__main__.py
+++ b/extract_msg/__main__.py
@@ -13,7 +13,7 @@ from extract_msg.enums import ErrorBehavior
 from typing import List
 
 
-def main(argv : List[str]) -> None:
+def main(argv: List[str] = sys.argv) -> None:
     # Setup logging to stdout, indicate running from cli
     CLI_LOGGING = 'extract_msg_cli'
     args = utils.getCommandArgs(argv[1:])


### PR DESCRIPTION
**v0.48.4**
* [[TeamMsgExtractor #411](https://github.com/TeamMsgExtractor/msg-extractor/issues/411)] Fix console script throwing error due to changed console args not defaulting.