### PR TITLE
Fix #414

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.48.5**
+* [[TeamMsgExtractor #414](https://github.com/TeamMsgExtractor/msg-extractor/issues/414)] Fixed typo in `message_signed_base.py`.
+
 **v0.48.4**
 * [[TeamMsgExtractor #411](https://github.com/TeamMsgExtractor/msg-extractor/issues/411)] Fix console script throwing error due to changed console args not defaulting.
 

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.4-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.48.4/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.5-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.48.5/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-03-20'
-__version__ = '0.48.4'
+__date__ = '2024-04-03'
+__version__ = '0.48.5'
 
 __all__ = [
     # Modules:

--- a/extract_msg/msg_classes/message_signed_base.py
+++ b/extract_msg/msg_classes/message_signed_base.py
@@ -130,7 +130,7 @@ class MessageSignedBase(MessageBase, Generic[_T]):
         elif self.body:
             # Convert the plain text body to html.
             logger.info('HTML body was not found, attempting to generate from plain text body.')
-            correctedBody = html.escpae(self.body).replace('\r', '').replace('\n', '<br />')
+            correctedBody = html.escape(self.body).replace('\r', '').replace('\n', '<br />')
             htmlBody = f'<html><body>{correctedBody}</body></head>'.encode('utf-8')
         else:
             logger.info('HTML body could not be found nor generated.')


### PR DESCRIPTION
**v0.48.5**
* [[TeamMsgExtractor #414](https://github.com/TeamMsgExtractor/msg-extractor/issues/414)] Fixed typo in `message_signed_base.py`.