### PR TITLE
Version 0.48.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.48.6**
+* [[TeamMsgExtractor #417](https://github.com/TeamMsgExtractor/msg-extractor/issues/417)] Fixed issues with `openMsg` where some corrupted MSG files could end up throwing an uncaught exception and leaving the file handle open.
+
 **v0.48.5**
 * [[TeamMsgExtractor #414](https://github.com/TeamMsgExtractor/msg-extractor/issues/414)] Fixed typo in `message_signed_base.py`.
 

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.5-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.48.5/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.6-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.48.6/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-04-03'
-__version__ = '0.48.5'
+__date__ = '2024-07-06'
+__version__ = '0.48.6'
 
 __all__ = [
     # Modules:


### PR DESCRIPTION
**v0.48.6**
* [[TeamMsgExtractor #417](https://github.com/TeamMsgExtractor/msg-extractor/issues/417)] Fixed issues with `openMsg` where some corrupted MSG files could end up throwing an uncaught exception and leaving the file handle open.