### PR TITLE
Version 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 **v0.49.0**
+* [[TeamMsgExtractor #427](https://github.com/TeamMsgExtractor/msg-extractor/issues/427)] Adjusted code for converting time stamps to create null dates for any time stamp beyond a certain point. The point was determined to be close to the existing null dates.
+* [[TeamMsgExtractor #425](https://github.com/TeamMsgExtractor/msg-extractor/issues/425)] Added basic support for custom attachments that are Windows Metafiles.
 * Changed tolerance of bitmap custom attachment handler to allow for attachments with only a CONTENT stream. This change was made after seeing an example of a file that only had a CONTENT stream and no other streams for the custom data. The code now also tries to create default values for things previously determined from those other streams.
 * Fixed an issue in `tryGetMimetype` were the code didn't properly check if the data type was bytes (it only checked if it had a type).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * [[TeamMsgExtractor #425](https://github.com/TeamMsgExtractor/msg-extractor/issues/425)] Added basic support for custom attachments that are Windows Metafiles.
 * Changed tolerance of bitmap custom attachment handler to allow for attachments with only a CONTENT stream. This change was made after seeing an example of a file that only had a CONTENT stream and no other streams for the custom data. The code now also tries to create default values for things previously determined from those other streams.
 * Fixed an issue in `tryGetMimetype` were the code didn't properly check if the data type was bytes (it only checked if it had a type).
+* Corrected some exports.
+* Added new `ErrorBehavior` value `CUSTOM_ATTACH_TOLERANT` to allow skipping checks for unused data that is normally validated.
 
 **v0.48.7**
 * [[TeamMsgExtractor #420](https://github.com/TeamMsgExtractor/msg-extractor/issues/420)] Fixed typo introduced in last version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.48.6**
+* [[TeamMsgExtractor #417](https://github.com/TeamMsgExtractor/msg-extractor/issues/417)] Fixed issues with `openMsg` where some corrupted MSG files could end up throwing an uncaught exception and leaving the file handle open.
+
 **v0.48.5**
 * [[TeamMsgExtractor #414](https://github.com/TeamMsgExtractor/msg-extractor/issues/414)] Fixed typo in `message_signed_base.py`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.48.7**
+* [[TeamMsgExtractor #420](https://github.com/TeamMsgExtractor/msg-extractor/issues/420)] Fixed typo introduced in last version.
+
 **v0.48.6**
 * [[TeamMsgExtractor #417](https://github.com/TeamMsgExtractor/msg-extractor/issues/417)] Fixed issues with `openMsg` where some corrupted MSG files could end up throwing an uncaught exception and leaving the file handle open.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.49.0**
+* Changed tolerance of bitmap custom attachment handler to allow for attachments with only a CONTENT stream. This change was made after seeing an example of a file that only had a CONTENT stream and no other streams for the custom data. The code now also tries to create default values for things previously determined from those other streams.
+* Fixed an issue in `tryGetMimetype` were the code didn't properly check if the data type was bytes (it only checked if it had a type).
+
 **v0.48.7**
 * [[TeamMsgExtractor #420](https://github.com/TeamMsgExtractor/msg-extractor/issues/420)] Fixed typo introduced in last version.
 

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.6-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.48.6/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.7-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.48.7/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.7-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.48.7/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.49.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.49.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.5-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.48.5/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.48.6-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.48.6/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,7 +27,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-08-19'
+__date__ = '2024-08-21'
 __version__ = '0.49.0'
 
 __all__ = [

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-07-06'
-__version__ = '0.48.6'
+__date__ = '2024-07-07'
+__version__ = '0.48.7'
 
 __all__ = [
     # Modules:

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-07-07'
-__version__ = '0.48.7'
+__date__ = '2024-07-19'
+__version__ = '0.49.0'
 
 __all__ = [
     # Modules:

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-04-03'
-__version__ = '0.48.5'
+__date__ = '2024-07-06'
+__version__ = '0.48.6'
 
 __all__ = [
     # Modules:

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,7 +27,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-07-19'
+__date__ = '2024-08-19'
 __version__ = '0.49.0'
 
 __all__ = [

--- a/extract_msg/attachments/custom_att_handler/outlook_image_dib.py
+++ b/extract_msg/attachments/custom_att_handler/outlook_image_dib.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 __all__ = [
-    'OutlookImage',
+    'OutlookImageDIB',
 ]
 
 

--- a/extract_msg/attachments/custom_att_handler/outlook_image_dib.py
+++ b/extract_msg/attachments/custom_att_handler/outlook_image_dib.py
@@ -12,7 +12,7 @@ from typing import Optional, TYPE_CHECKING
 
 from . import registerHandler
 from .custom_handler import CustomAttachmentHandler
-from ...enums import DVAspect, InsecureFeatures
+from ...enums import DVAspect, ErrorBehavior, InsecureFeatures
 from ...exceptions import DependencyError, SecurityError
 
 
@@ -61,27 +61,29 @@ class OutlookImageDIB(CustomAttachmentHandler):
         self.__xtwips = int(round(self.__x / 1.7639))
         self.__ytwips = int(round(self.__y / 1.7639))
 
-        # Get the OLE data.
-        oleStream = self.getStream('\x01Ole')
-        if oleStream:
-            # While I have only seen this stream be one length, it could in 
-            # theory be more than one length. So long as it is *at least* 20 
-            # bytes, we call it valid.
-            if len(oleStream) < 20:
-                raise ValueError('OLE stream is too short.')
-            # Unpack and verify the OLE stream.
-            vals = _ST_OLE.unpack(oleStream[:20])
-            # Check the version magic.
-            if vals[0] != 0x2000001:
-                raise ValueError('OLE stream has wrong version magic.')
-            # Check the reserved bytes.
-            if vals[3] != 0:
-                raise ValueError('OLE stream has non-zero reserved int.')
-        else:
-            #raise ValueError('OLE stream could not be found.')
-            # If the stream is there we validate it, so here we just leave it 
-            # alone since nothing is actually stored.
-            pass
+        # Check the error behavior to see if we should even do this check.
+        if ErrorBehavior.CUSTOM_ATTACH_TOLERANT not in attachment.msg.errorBehavior:
+            # Get the OLE data.
+            oleStream = self.getStream('\x01Ole')
+            if oleStream:
+                # While I have only seen this stream be one length, it could in
+                # theory be more than one length. So long as it is *at least* 20
+                # bytes, we call it valid.
+                if len(oleStream) < 20:
+                    raise ValueError('OLE stream is too short.')
+                # Unpack and verify the OLE stream.
+                vals = _ST_OLE.unpack(oleStream[:20])
+                # Check the version magic.
+                if vals[0] != 0x2000001:
+                    raise ValueError('OLE stream has wrong version magic.')
+                # Check the reserved bytes.
+                if vals[3] != 0:
+                    raise ValueError('OLE stream has non-zero reserved int.')
+            else:
+                #raise ValueError('OLE stream could not be found.')
+                # If the stream is there we validate it, so here we just leave 
+                # it alone since nothing is actually stored.
+                pass
 
     @classmethod
     def isCorrectHandler(cls, attachment: AttachmentBase) -> bool:

--- a/extract_msg/attachments/custom_att_handler/outlook_image_meta.py
+++ b/extract_msg/attachments/custom_att_handler/outlook_image_meta.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+
+__all__ = [
+    'OutlookImage',
+]
+
+
+import struct
+
+from typing import Optional, TYPE_CHECKING
+
+from . import registerHandler
+from .custom_handler import CustomAttachmentHandler
+from ...enums import DVAspect, InsecureFeatures
+from ...exceptions import DependencyError, SecurityError
+
+
+if TYPE_CHECKING:
+    from ..attachment_base import AttachmentBase
+
+_ST_OLE = struct.Struct('<IIIII')
+_ST_MAILSTREAM = struct.Struct('<III')
+
+
+class OutlookImageMetafile(CustomAttachmentHandler):
+    """
+    Custom handler for a special attachment type, a Device Independent Bitmap
+    stored in a way special to Outlook.
+    """
+
+    def __init__(self, attachment: AttachmentBase):
+        super().__init__(attachment)
+        # First, get the mandatory bitmap data.
+        self.__data = self.getStream('CONTENTS')
+        if not self.__data:
+            raise ValueError('Bitmap data could not be read for Outlook signature.')
+
+        # Next we need to get the mailstream.
+        stream = self.getStream('\x03MailStream')
+        if stream:
+            if len(stream) != 12:
+                raise ValueError('MailStream is the wrong length.')
+
+            # Unpack the mailstream.
+            vals = _ST_MAILSTREAM.unpack(stream)
+            self.__dvaspect = DVAspect(vals[0])
+            self.__x = vals[1]
+            self.__y = vals[2]
+        else:
+            #raise ValueError('MailStream could not be found.')
+            # Create default values.
+            self.__dvaspect = DVAspect.CONTENT
+            # TODO figure out what the default values for these should actually
+            # be.
+            self.__x = 0
+            self.__y = 0
+
+        # This is done regardless of default values or not.
+        # Convert to twips for RTF.
+        self.__xtwips = int(round(self.__x / 1.7639))
+        self.__ytwips = int(round(self.__y / 1.7639))
+
+        # Get the OLE data.
+        oleStream = self.getStream('\x01Ole')
+        if oleStream:
+            # While I have only seen this stream be one length, it could in
+            # theory be more than one length. So long as it is *at least* 20
+            # bytes, we call it valid.
+            if len(oleStream) < 20:
+                raise ValueError('OLE stream is too short.')
+            # Unpack and verify the OLE stream.
+            vals = _ST_OLE.unpack(oleStream[:20])
+            # Check the version magic.
+            if vals[0] != 0x2000001:
+                raise ValueError('OLE stream has wrong version magic.')
+            # Check the reserved bytes.
+            if vals[3] != 0:
+                raise ValueError('OLE stream has non-zero reserved int.')
+        else:
+            #raise ValueError('OLE stream could not be found.')
+            # If the stream is there we validate it, so here we just leave it
+            # alone since nothing is actually stored.
+            pass
+
+    @classmethod
+    def isCorrectHandler(cls, attachment: AttachmentBase) -> bool:
+        if attachment.clsid != '00000315-0000-0000-C000-000000000046':
+            return False
+
+        # Check for the required streams.
+        if not attachment.exists('__substg1.0_3701000D/CONTENTS'):
+            return False
+        # These streams were previously considered mandatory, but are now
+        # tentatively optional.
+        #if not attachment.exists('__substg1.0_3701000D/\x01Ole'):
+        #    return False
+        #if not attachment.exists('__substg1.0_3701000D/\x03MailStream'):
+        #    return False
+
+        return True
+
+    def generateRtf(self) -> Optional[bytes]:
+        """
+        Generates the RTF to inject in place of the \\objattph tag.
+
+        If this function should do nothing, returns ``None``.
+
+        :raises DependencyError: PIL or Pillow could not be found.
+        """
+        if InsecureFeatures.PIL_IMAGE_PARSING not in self.attachment.msg.insecureFeatures:
+            raise SecurityError('Generating the RTF for a custom attachment requires the insecure feature PIL_IMAGE_PARSING.')
+
+        try:
+            import PIL.Image
+        except ImportError:
+            raise DependencyError('PIL or Pillow is required for inserting an Outlook Image into the body.')
+
+        # First, convert the bitmap into a PNG so we can insert it into the
+        # body.
+        import io
+
+        # Note, use self.data instead of self.__data to allow support for
+        # extensions.
+        with PIL.Image.open(io.BytesIO(self.data)) as img:
+            out = io.BytesIO()
+            img.save(out, 'PNG')
+
+        hexData = out.getvalue().hex()
+
+        inject = '{\\*\\shppict\n{\\pict\\picscalex100\\picscaley100'
+        inject += f'\\picw{img.width}\\pich{img.height}'
+        inject += f'\\picwgoal{self.__xtwips}\\pichgoal{self.__ytwips}\n'
+        inject += '\\pngblip ' + hexData + '}}'
+
+        return inject.encode()
+
+    @property
+    def data(self) -> bytes:
+        return self.__data
+
+    @property
+    def name(self) -> str:
+        # Try to get the name from the attachment. If that fails, name it based
+        # on the number.
+        if not (name := self.attachment.name):
+            name = f'attachment {int(self.attachment.dir[-8:], 16)}'
+        return name + '.bmp'
+
+    @property
+    def obj(self) -> bytes:
+        return self.data
+
+
+
+registerHandler(OutlookImageMetafile)

--- a/extract_msg/attachments/custom_att_handler/outlook_image_meta.py
+++ b/extract_msg/attachments/custom_att_handler/outlook_image_meta.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 __all__ = [
-    'OutlookImage',
+    'OutlookImageMetafile',
 ]
 
 

--- a/extract_msg/attachments/custom_att_handler/outlook_image_meta.py
+++ b/extract_msg/attachments/custom_att_handler/outlook_image_meta.py
@@ -12,7 +12,7 @@ from typing import Optional, TYPE_CHECKING
 
 from . import registerHandler
 from .custom_handler import CustomAttachmentHandler
-from ...enums import DVAspect, InsecureFeatures
+from ...enums import DVAspect, ErrorBehavior, InsecureFeatures
 from ...exceptions import DependencyError, SecurityError
 
 
@@ -61,27 +61,29 @@ class OutlookImageMetafile(CustomAttachmentHandler):
         self.__xtwips = int(round(self.__x / 1.7639))
         self.__ytwips = int(round(self.__y / 1.7639))
 
-        # Get the OLE data.
-        oleStream = self.getStream('\x01Ole')
-        if oleStream:
-            # While I have only seen this stream be one length, it could in
-            # theory be more than one length. So long as it is *at least* 20
-            # bytes, we call it valid.
-            if len(oleStream) < 20:
-                raise ValueError('OLE stream is too short.')
-            # Unpack and verify the OLE stream.
-            vals = _ST_OLE.unpack(oleStream[:20])
-            # Check the version magic.
-            if vals[0] != 0x2000001:
-                raise ValueError('OLE stream has wrong version magic.')
-            # Check the reserved bytes.
-            if vals[3] != 0:
-                raise ValueError('OLE stream has non-zero reserved int.')
-        else:
-            #raise ValueError('OLE stream could not be found.')
-            # If the stream is there we validate it, so here we just leave it
-            # alone since nothing is actually stored.
-            pass
+        # Check the error behavior to see if we should even do this check.
+        if ErrorBehavior.CUSTOM_ATTACH_TOLERANT not in attachment.msg.errorBehavior:
+            # Get the OLE data.
+            oleStream = self.getStream('\x01Ole')
+            if oleStream:
+                # While I have only seen this stream be one length, it could in
+                # theory be more than one length. So long as it is *at least* 20
+                # bytes, we call it valid.
+                if len(oleStream) < 20:
+                    raise ValueError('OLE stream is too short.')
+                # Unpack and verify the OLE stream.
+                vals = _ST_OLE.unpack(oleStream[:20])
+                # Check the version magic.
+                if vals[0] != 0x2000001:
+                    raise ValueError('OLE stream has wrong version magic.')
+                # Check the reserved bytes.
+                if vals[3] != 0:
+                    raise ValueError('OLE stream has non-zero reserved int.')
+            else:
+                #raise ValueError('OLE stream could not be found.')
+                # If the stream is there we validate it, so here we just leave 
+                # it alone since nothing is actually stored.
+                pass
 
     @classmethod
     def isCorrectHandler(cls, attachment: AttachmentBase) -> bool:

--- a/extract_msg/enums.py
+++ b/extract_msg/enums.py
@@ -666,8 +666,10 @@ class ErrorBehavior(enum.IntFlag):
     * THROW: Throw the exception regardless of type.
     * ATTACH_NOT_IMPLEMENTED: Silence the exception for NotImplementedError.
     * ATTACH_BROKEN: Silence the exception for broken attachments.
-    * ATTACH_SUPPRESS_ALL: Silence the exception for NotImplementedError and for
-      broken attachments.
+    * CUSTOM_ATTACH_TOLERANT: Makes custom attachments more tolerant for 
+      data that is validated but not used.
+    * ATTACH_SUPPRESS_ALL: Silence the exception for NotImplementedError, for
+      broken attachments, and for custom attachment issues.
     * RTFDE_MALFORMED: Silences errors about malformed RTF data.
     * RTFDE_UNKNOWN_ERROR: Silences errors from RTFDE that are not normal.
     * RTFDE: Silences all errors from RTFDE.
@@ -679,22 +681,23 @@ class ErrorBehavior(enum.IntFlag):
       simply be dropped.
     * SUPPRESS_ALL: Silences all of the above.
     """
-    THROW = 0b000000
+    THROW = 0b00000000
     # Attachments.
-    ATTACH_NOT_IMPLEMENTED = 0b000001
-    ATTACH_BROKEN = 0b000010
-    ATTACH_SUPPRESS_ALL = 0b000011
+    ATTACH_NOT_IMPLEMENTED = 0b00000001
+    ATTACH_BROKEN = 0b00000010
+    CUSTOM_ATTACH_TOLERANT = 0b00000100
+    ATTACH_SUPPRESS_ALL = 0b00000111
     # RTFDE.
-    RTFDE_MALFORMED = 0b000100
-    RTFDE_UNKNOWN_ERROR = 0b001000
-    RTFDE = 0b001100
+    RTFDE_MALFORMED = 0b00001000
+    RTFDE_UNKNOWN_ERROR = 0b00010000
+    RTFDE = 0b00011000
     # General.
-    STANDARDS_VIOLATION = 0b010000
-    OLE_DEFECT_INCORRECT = 0b100000
-    # Named Properties
-    NAMED_NAME_STREAM = 0b1000000
+    STANDARDS_VIOLATION = 0b00100000
+    OLE_DEFECT_INCORRECT = 0b01000000
+    # Named Properties.
+    NAMED_NAME_STREAM = 0b10000000
 
-    SUPPRESS_ALL = 0b1111111
+    SUPPRESS_ALL = 0b111111111111
 
 
 

--- a/extract_msg/open_msg.py
+++ b/extract_msg/open_msg.py
@@ -107,7 +107,7 @@ def openMsg(path, **kwargs) -> MSGFile:
     # other file types (like doc, ppt, etc.) might open but not return a class
     # type. If the stream is not found, classType returns None, which has no
     # lower function. So let's make sure we got a good return first.
-    if not cy:
+    if not ct:
         if kwargs.get('strict', True):
             raise InvalidFileFormatError('File was confirmed to be an olefile, but was not an MSG file.')
         else:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -1006,7 +1006,7 @@ def tryGetMimetype(att: AttachmentBase, mimetype: Union[str, None]) -> Union[str
         return mimetype
 
     # We only try anything if the data is bytes.
-    if att.dataType:
+    if att.dataType is bytes:
         # Try to import our dependency module to use it.
         try:
             import magic # pyright: ignore

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -291,6 +291,13 @@ def filetimeToDatetime(rawTime: int) -> datetime.datetime:
             return date
         elif rawTime == 915046235400000000:
             return constants.NULL_DATE
+        elif rawTime > 915000000000000000:
+            # Just make null dates from all of these time stamps.
+            from .null_date import NullDate
+            date = NullDate(1970, 1, 1, 1)
+            date += datetime.timedelta(seconds = filetimeToUtc(rawTime))
+
+            return date
         else:
             return fromTimeStamp(filetimeToUtc(rawTime))
     except TZError:

--- a/extract_msg/utils.py
+++ b/extract_msg/utils.py
@@ -296,6 +296,7 @@ def filetimeToDatetime(rawTime: int) -> datetime.datetime:
             from .null_date import NullDate
             date = NullDate(1970, 1, 1, 1)
             date += datetime.timedelta(seconds = filetimeToUtc(rawTime))
+            date.filetime = rawTime
 
             return date
         else:
@@ -304,7 +305,7 @@ def filetimeToDatetime(rawTime: int) -> datetime.datetime:
         # For TZError we just raise it again. It is a fatal error.
         raise
     except Exception:
-        raise ValueError(f'Timestamp value of {filetimeToUtc(rawTime)} caused an exception. This was probably caused by the time stamp being too far in the future.')
+        raise ValueError(f'Timestamp value of {filetimeToUtc(rawTime)} (raw: {rawTime}) caused an exception. This was probably caused by the time stamp being too far in the future.')
 
 
 def filetimeToUtc(inp: int) -> float:

--- a/extract_msg_tests/cmd_line_tests.py
+++ b/extract_msg_tests/cmd_line_tests.py
@@ -3,7 +3,6 @@ __all__ = [
 ]
 
 
-import pathlib
 import subprocess
 import sys
 import unittest

--- a/extract_msg_tests/prop_tests.py
+++ b/extract_msg_tests/prop_tests.py
@@ -197,6 +197,16 @@ _propChecks = [
         PropertyFlags.MANDATORY,
         NULL_DATE
     ),
+    (
+        'Null Time 3',
+        b'\x40\x00\x01\x02\x01\x00\x00\x00\x00\x3F\xDD\xA3\x57\x45\xB3\x0C',
+        b'\x40\x00\x01\x02\x01\x00\x00\x00\x00\x3F\xDD\xA3\x57\x45\xB3\x0C',
+        FixedLengthProp,
+        '02010040',
+        0x0040,
+        PropertyFlags.MANDATORY,
+        NULL_DATE
+    ),
     # Variable Length Props.
     (
         'Object',


### PR DESCRIPTION
**v0.49.0**
* [[TeamMsgExtractor #427](https://github.com/TeamMsgExtractor/msg-extractor/issues/427)] Adjusted code for converting time stamps to create null dates for any time stamp beyond a certain point. The point was determined to be close to the existing null dates.
* [[TeamMsgExtractor #425](https://github.com/TeamMsgExtractor/msg-extractor/issues/425)] Added basic support for custom attachments that are Windows Metafiles.
* Changed tolerance of bitmap custom attachment handler to allow for attachments with only a CONTENT stream. This change was made after seeing an example of a file that only had a CONTENT stream and no other streams for the custom data. The code now also tries to create default values for things previously determined from those other streams.
* Fixed an issue in `tryGetMimetype` were the code didn't properly check if the data type was bytes (it only checked if it had a type).
* Corrected some exports.
* Added new `ErrorBehavior` value `CUSTOM_ATTACH_TOLERANT` to allow skipping checks for unused data that is normally validated.