### PR TITLE
v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.50.0**
+* [[TeamMsgExtractor #432](https://github.com/TeamMsgExtractor/msg-extractor/issues/432)] Adjust html header code to replace non-ascii characters with escaped versions.
+
 **v0.49.0**
 * [[TeamMsgExtractor #427](https://github.com/TeamMsgExtractor/msg-extractor/issues/427)] Adjusted code for converting time stamps to create null dates for any time stamp beyond a certain point. The point was determined to be close to the existing null dates.
 * [[TeamMsgExtractor #425](https://github.com/TeamMsgExtractor/msg-extractor/issues/425)] Added basic support for custom attachments that are Windows Metafiles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **v0.50.0**
-* [[TeamMsgExtractor #432](https://github.com/TeamMsgExtractor/msg-extractor/issues/432)] Adjust html header code to replace non-ascii characters with escaped versions.
+* [[TeamMsgExtractor #432](https://github.com/TeamMsgExtractor/msg-extractor/issues/432)] Adjust html header code to replace non-ascii characters with escaped versions. Also adujusted plain text to html conversion to ensure non-ascii character from the body are encoded to escpaed values to be safe.
+* Made some corrections to `NullDate`.
 
 **v0.49.0**
 * [[TeamMsgExtractor #427](https://github.com/TeamMsgExtractor/msg-extractor/issues/427)] Adjusted code for converting time stamps to create null dates for any time stamp beyond a certain point. The point was determined to be close to the existing null dates.

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.49.0-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.49.0/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.50.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.50.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-08-21'
-__version__ = '0.49.0'
+__date__ = '2024-10-02'
+__version__ = '0.50.0'
 
 __all__ = [
     # Modules:

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,7 +27,7 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-10-02'
+__date__ = '2024-10-07'
 __version__ = '0.50.0'
 
 __all__ = [

--- a/extract_msg/msg_classes/message_base.py
+++ b/extract_msg/msg_classes/message_base.py
@@ -1213,7 +1213,7 @@ class MessageBase(MSGFile):
         prefix = '<div id="injectedHeader"><div><p class="MsoNormal">'
         suffix = '<o:p></o:p></p></div></div>'
         joinStr = '<br/>'
-        formatter = (lambda name, value: f'<b>{name}:</b>&nbsp;{inputToString(htmlSanitize(value), self.stringEncoding)}')
+        formatter = (lambda name, value: f'<b>{name}:</b>&nbsp;{inputToString(htmlSanitize(value), self.stringEncoding).encode("ascii", "xmlcharrefreplace").decode()}')
 
         return self.getInjectableHeader(prefix, joinStr, suffix, formatter)
 

--- a/extract_msg/msg_classes/message_base.py
+++ b/extract_msg/msg_classes/message_base.py
@@ -1163,14 +1163,14 @@ class MessageBase(MSGFile):
             pass
         elif self.rtfBody:
             logger.info('HTML body was not found, attempting to generate from RTF.')
-            htmlBody = self.deencapsulateBody(self.rtfBody, DeencapType.HTML)
+            htmlBody = cast(bytes, self.deencapsulateBody(self.rtfBody, DeencapType.HTML))
         # This is it's own if statement so we can ensure it will generate
         # even if there is an rtfBody, in the event it doesn't have HTML.
         if not htmlBody and self.body:
             # Convert the plain text body to html.
             logger.info('HTML body was not found, attempting to generate from plain text body.')
             correctedBody = html.escape(self.body).replace('\r', '').replace('\n', '<br />')
-            htmlBody = f'<html><body>{correctedBody}</body></head>'.encode('utf-8')
+            htmlBody = f'<html><body>{correctedBody}</body></head>'.encode('ascii', 'xmlreplace')
 
         if not htmlBody:
             logger.info('HTML body could not be found nor generated.')
@@ -1213,7 +1213,7 @@ class MessageBase(MSGFile):
         prefix = '<div id="injectedHeader"><div><p class="MsoNormal">'
         suffix = '<o:p></o:p></p></div></div>'
         joinStr = '<br/>'
-        formatter = (lambda name, value: f'<b>{name}:</b>&nbsp;{inputToString(htmlSanitize(value), self.stringEncoding).encode("ascii", "xmlcharrefreplace").decode()}')
+        formatter = (lambda name, value: f'<b>{name}:</b>&nbsp;{inputToString(htmlSanitize(value), self.stringEncoding).encode('ascii', 'xmlcharrefreplace').decode()}')
 
         return self.getInjectableHeader(prefix, joinStr, suffix, formatter)
 

--- a/extract_msg/null_date.py
+++ b/extract_msg/null_date.py
@@ -26,9 +26,9 @@ class NullDate(datetime.datetime):
     def __eq__(self, other) -> bool:
         if isinstance(other, NullDate):
             return True
-        return super.__eq__(self, other)
+        return super().__eq__(other)
 
     def __ne__(self, other) -> bool:
         if isinstance(other, NullDate):
             return False
-        return super.__eq__(self, other)
+        return super().__eq__(other)


### PR DESCRIPTION
**v0.50.0**
* [[TeamMsgExtractor #432](https://github.com/TeamMsgExtractor/msg-extractor/issues/432)] Adjust html header code to replace non-ascii characters with escaped versions. Also adujusted plain text to html conversion to ensure non-ascii character from the body are encoded to escpaed values to be safe.
* Made some corrections to `NullDate`.