### PR TITLE
Add support for MSG class type "IPM.SkypeTeams.Message"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.51.0**
+* [[TeamMsgExtractor #401](https://github.com/TeamMsgExtractor/msg-extractor/issues/401)] Add support for MSG class type "IPM.SkypeTeams.Message".
+
 **v0.50.1**
 * [[TeamMsgExtractor #434](https://github.com/TeamMsgExtractor/msg-extractor/issues/434)] Fix bug introduced in previous version.
 

--- a/extract_msg/open_msg.py
+++ b/extract_msg/open_msg.py
@@ -116,7 +116,7 @@ def openMsg(path, **kwargs) -> MSGFile:
             return msg
     classType = ct.lower()
     # Put the message class first as it is most common.
-    if classType.startswith('ipm.note') or classType.startswith('report'):
+    if classType.startswith('ipm.note') or classType.startswith('report') or classType.startswith('ipm.skypeteams.message'):
         msg.close()
         if classType.endswith('smime.multipartsigned') or classType.endswith('smime'):
             return MessageSigned(path, **kwargs)


### PR DESCRIPTION
- [x] Issue #401
- [x] Have you listed any changes to install or build dependencies?
- [x] Ensured your changes are compatible with Python 2.7 (ONLY FOR v0.29).
- [x] Have you updated the [CHANGELOG](CHANGELOG.md) with details of changes to the codebase, this includes new functionality, deprecated features, or any other material changes.
- [ ] If necessary, have you bumped the version number? We will usually do this for you.
- [ ] Have you included py.test tests with your pull request. (Not yet necessary)
- [x] Ensured your code is as close to PEP 8 compliant as possible?
- [x] Ensured your pull request is to the `next-release` branch (or `v0.29` if applicable)?

In this PR, I updated the library to recognize the class "IPM.SkypeTeams.Message" as a message type. I verified that this fixes the problem on 107 different MSG files with the class "IPM.SkypeTeams.Message". Closes #401.