### PR TITLE
Version 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v0.52.0**
+* [[TeamMsgExtractor #444](https://github.com/TeamMsgExtractor/msg-extractor/issues/444)] Fix typo in string that prevented HTML body from generating from the plain text body properly.
+* Adjusted the behavior of `MSGFile.areStringsUnicode` to prioritize the property specified by the parent MSG files for MSG files that are embedded. Additionally, added a fallback to rely on whether or not there is a stream using the `001F` type to determine the property value if it is entirely missing.
+* Adjusted `OleWriter.fromMsg()` and `MSGFile.export()` to add the argument `allowBadEmbed` which helps to correct a few different issues that may appear in embedded MSG files. These corrections allow the extracte file to still be extracted and to open properly in Outlook.
+* In addition to the above, the errors that some of those corrections will surpress are now significantly more informative about what went wrong.
+
 **v0.51.1**
 * Add class type added in last version to known class types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 **v0.52.0**
 * [[TeamMsgExtractor #444](https://github.com/TeamMsgExtractor/msg-extractor/issues/444)] Fix typo in string that prevented HTML body from generating from the plain text body properly.
 * Adjusted the behavior of `MSGFile.areStringsUnicode` to prioritize the property specified by the parent MSG files for MSG files that are embedded. Additionally, added a fallback to rely on whether or not there is a stream using the `001F` type to determine the property value if it is entirely missing.
-* Adjusted `OleWriter.fromMsg()` and `MSGFile.export()` to add the argument `allowBadEmbed` which helps to correct a few different issues that may appear in embedded MSG files. These corrections allow the extracte file to still be extracted and to open properly in Outlook.
-* In addition to the above, the errors that some of those corrections will surpress are now significantly more informative about what went wrong.
+* Adjusted `OleWriter.fromMsg()` and `MSGFile.export()` to add the argument `allowBadEmbed` which helps to correct a few different issues that may appear in embedded MSG files. These corrections allow the embedded file to still be extracted and to open properly in Outlook.
+* In addition to the above, the errors that some of those corrections will suppress are now significantly more informative about what went wrong.
 
 **v0.51.1**
 * Add class type added in last version to known class types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 **v0.51.1**
-* Add class type added ion last version to known class types.
+* Add class type added in last version to known class types.
 
 **v0.51.0**
 * [[TeamMsgExtractor #401](https://github.com/TeamMsgExtractor/msg-extractor/issues/401)] Add basic support for MSG class type `IPM.SkypeTeams.Message`.

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.51.1-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.51.1/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.52.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.52.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2024-10-11'
-__version__ = '0.51.1'
+__date__ = '2024-10-22'
+__version__ = '0.52.0'
 
 __all__ = [
     # Modules:

--- a/extract_msg/msg_classes/message_base.py
+++ b/extract_msg/msg_classes/message_base.py
@@ -1170,7 +1170,7 @@ class MessageBase(MSGFile):
             # Convert the plain text body to html.
             logger.info('HTML body was not found, attempting to generate from plain text body.')
             correctedBody = html.escape(self.body).replace('\r', '').replace('\n', '<br />')
-            htmlBody = f'<html><body>{correctedBody}</body></head>'.encode('ascii', 'xmlreplace')
+            htmlBody = f'<html><body>{correctedBody}</body></head>'.encode('ascii', 'xmlcharrefreplace')
 
         if not htmlBody:
             logger.info('HTML body could not be found nor generated.')

--- a/extract_msg/msg_classes/msg.py
+++ b/extract_msg/msg_classes/msg.py
@@ -843,7 +843,7 @@ class MSGFile:
         """
         Whether the strings are Unicode encoded or not.
         """
-        val = self.getPropertyVal('340D0003', None)
+        val = self.getPropertyVal('340D0003')
         if val is None:
             # Try to get this value from the parent.
             if self.prefix:

--- a/extract_msg/msg_classes/msg.py
+++ b/extract_msg/msg_classes/msg.py
@@ -492,6 +492,8 @@ class MSGFile:
 
         :param path: A path-like object (including strings and ``pathlib.Path``
             objects) or an IO device with a write method which accepts bytes.
+        :param allowBadEmbed: If True, attempts to skip steps that will fail if 
+            the embedded MSG file violates standards. It will also attempt to repair the data to try to ensure it can open in Outlook.
         """
         from ..ole_writer import OleWriter
 
@@ -504,9 +506,12 @@ class MSGFile:
     def exportBytes(self, allowBadEmbed: bool = False) -> bytes:
         """
         Saves a new copy of the MSG file, returning the bytes.
+
+        :param allowBadEmbed: If True, attempts to skip steps that will fail if 
+            the embedded MSG file violates standards. It will also attempt to repair the data to try to ensure it can open in Outlook.
         """
         out = io.BytesIO()
-        self.export(out)
+        self.export(out, allowBadEmbed)
         return out.getvalue()
 
     def fixPath(self, inp: MSG_PATH, prefix: bool = True) -> str:

--- a/extract_msg/msg_classes/msg.py
+++ b/extract_msg/msg_classes/msg.py
@@ -843,7 +843,16 @@ class MSGFile:
         """
         Whether the strings are Unicode encoded or not.
         """
-        return (self.getPropertyVal('340D0003', 0) & 0x40000) != 0
+        val = self.getPropertyVal('340D0003', None)
+        if val is None:
+            # Try to get this value from the parent.
+            if self.prefix:
+                if self.__parentMsg and (msg := self.__parentMsg()) is not None:
+                    return msg.areStringsUnicode
+
+            # Final attempt: check the actual streams.
+            return any(x[-1].upper().endswith('001F') for x in self.listDir())
+        return (val & 0x40000) != 0
 
     @functools.cached_property
     def attachments(self) -> Union[List[AttachmentBase], List[SignedAttachment]]:

--- a/extract_msg/ole_writer.py
+++ b/extract_msg/ole_writer.py
@@ -808,8 +808,11 @@ class OleWriter:
         """
         Copies the streams and stream information necessary from the MSG file.
 
-        :param allowBadEmbed: If true, attempts to skip steps that will fail if 
-            the embedded msg file violates standards. It will also attempt to repair the data to try to ensure it can open in Outlook.
+        :param allowBadEmbed: If True, attempts to skip steps that will fail if 
+            the embedded MSG file violates standards. It will also attempt to repair the data to try to ensure it can open in Outlook.
+
+        :raises StandardViolationError: Something about the embedded data has a
+            fundemental issue that violates the standard.
         """
         # Get the root OLE entry's CLSID.
         self.__rootEntry.clsid = _unClsid(msg._getOleEntry('/').clsid)


### PR DESCRIPTION
**v0.52.0**
* [[TeamMsgExtractor #444](https://github.com/TeamMsgExtractor/msg-extractor/issues/444)] Fix typo in string that prevented HTML body from generating from the plain text body properly.
* Adjusted the behavior of `MSGFile.areStringsUnicode` to prioritize the property specified by the parent MSG files for MSG files that are embedded. Additionally, added a fallback to rely on whether or not there is a stream using the `001F` type to determine the property value if it is entirely missing.
* Adjusted `OleWriter.fromMsg()` and `MSGFile.export()` to add the argument `allowBadEmbed` which helps to correct a few different issues that may appear in embedded MSG files. These corrections allow the extracte file to still be extracted and to open properly in Outlook.
* In addition to the above, the errors that some of those corrections will surpress are now significantly more informative about what went wrong.