### PR TITLE
Version 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**v0.54.0**
+* [[TeamMsgExtractor #456](https://github.com/TeamMsgExtractor/msg-extractor/issues/456)] Changed the prepared html output to use plainly encoded html instead of prettified, since prettifying will mangle the HTML output for some reason.
+
 **v0.53.2**
 * [[TeamMsgExtractor #452](https://github.com/TeamMsgExtractor/msg-extractor/issues/452)] Adjusted code to allow html encoding to be cached to try to speed up `bs4` operations.
 * [[TeamMsgExtractor #453](https://github.com/TeamMsgExtractor/msg-extractor/issues/453)] Fixed handler for too large filetimes so that some filetimes being too large doesn't break the handler.

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,8 @@ your access to the newest major version of extract-msg.
 .. |License: GPL v3| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
    :target: LICENSE.txt
 
-.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.53.2-blue.svg
-   :target: https://pypi.org/project/extract-msg/0.53.2/
+.. |PyPI3| image:: https://img.shields.io/badge/pypi-0.54.0-blue.svg
+   :target: https://pypi.org/project/extract-msg/0.54.0/
 
 .. |PyPI2| image:: https://img.shields.io/badge/python-3.8+-brightgreen.svg
    :target: https://www.python.org/downloads/release/python-3810/

--- a/extract_msg/__init__.py
+++ b/extract_msg/__init__.py
@@ -27,8 +27,8 @@ https://github.com/TeamMsgExtractor/msg-extractor
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = 'Destiny Peterson & Matthew Walker'
-__date__ = '2025-03-14'
-__version__ = '0.53.2'
+__date__ = '2025-03-23'
+__version__ = '0.54.0'
 
 __all__ = [
     # Modules:

--- a/extract_msg/msg_classes/message_base.py
+++ b/extract_msg/msg_classes/message_base.py
@@ -413,7 +413,7 @@ class MessageBase(MSGFile):
                             head.insert(0, tag)
                             bs.find('html').insert(0, head)
 
-                    data = bs.prettify('utf-8')
+                    data = bs.encode('utf-8')
 
             return data
         else:


### PR DESCRIPTION
**v0.54.0**
* [[TeamMsgExtractor #456](https://github.com/TeamMsgExtractor/msg-extractor/issues/456)] Changed the prepared html output to use plainly encoded html instead of prettified, since prettifying will mangle the HTML output for some reason.